### PR TITLE
Smaller Evac Shuttle

### DIFF
--- a/Resources/Maps/Shuttles/emergency.yml
+++ b/Resources/Maps/Shuttles/emergency.yml
@@ -99,7 +99,8 @@ tilemap:
 entities:
 - uid: 0
   components:
-  - type: MetaData
+  - name: Escape Pod
+    type: MetaData
   - pos: 0.48958334,0.74920964
     parent: invalid
     type: Transform
@@ -495,10 +496,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 22
-  type: Gyroscope
+  type: RCSThruster
   components:
-  - rot: 3.141592653589793 rad
-    pos: -5.5,-1.5
+  - pos: 3.5,2.5
     parent: 0
     type: Transform
   - type: AtmosDevice
@@ -697,19 +697,21 @@ entities:
     parent: 0
     type: Transform
 - uid: 51
-  type: ShuttleWindow
+  type: RCSThruster
   components:
   - rot: -1.5707963267948966 rad
-    pos: -0.5,-1.5
+    pos: 3.5,-5.5
     parent: 0
     type: Transform
+  - type: AtmosDevice
 - uid: 52
-  type: Grille
+  type: RCSThruster
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -0.5,-1.5
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,-5.5
     parent: 0
     type: Transform
+  - type: AtmosDevice
 - uid: 53
   type: CableHV
   components:
@@ -991,9 +993,9 @@ entities:
     type: Transform
   - type: AtmosDevice
 - uid: 97
-  type: Thruster
+  type: RCSThruster
   components:
-  - pos: -5.5,0.5
+  - pos: -4.5,2.5
     parent: 0
     type: Transform
   - type: AtmosDevice
@@ -1014,43 +1016,13 @@ entities:
     type: Transform
   - type: AtmosDevice
 - uid: 100
-  type: Thruster
+  type: Gyroscope
   components:
-  - pos: 4.5,0.5
+  - pos: -0.5,-1.5
     parent: 0
     type: Transform
-  - type: AtmosDevice
-- uid: 101
-  type: Thruster
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: 3.5,2.5
-    parent: 0
-    type: Transform
-  - type: AtmosDevice
-- uid: 102
-  type: Thruster
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -4.5,2.5
-    parent: 0
-    type: Transform
-  - type: AtmosDevice
-- uid: 103
-  type: Thruster
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -4.5,-5.5
-    parent: 0
-    type: Transform
-  - type: AtmosDevice
-- uid: 104
-  type: Thruster
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: 3.5,-5.5
-    parent: 0
-    type: Transform
+  - baseThrust: 2000
+    type: Thruster
   - type: AtmosDevice
 - uid: 105
   type: CableApcExtension
@@ -1128,6 +1100,8 @@ entities:
   - pos: -0.5,1.5
     parent: 0
     type: Transform
+  - authorizationsRequired: 1
+    type: EmergencyShuttleConsole
   - type: AtmosDevice
 - uid: 117
   type: Catwalk
@@ -1198,15 +1172,6 @@ entities:
     pos: 1.5,-0.5
     parent: 0
     type: Transform
-- uid: 126
-  type: EmergencyLight
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -3.5,-1.5
-    parent: 0
-    type: Transform
-  - type: AtmosDevice
-  - type: ActiveEmergencyLight
 - uid: 127
   type: Catwalk
   components:

--- a/Resources/Maps/Shuttles/emergency.yml
+++ b/Resources/Maps/Shuttles/emergency.yml
@@ -17,102 +17,105 @@ tilemap:
   10: FloorAsteroidSand
   11: FloorAsteroidTile
   12: FloorBar
-  13: FloorBlue
-  14: FloorBlueCircuit
-  15: FloorBoxing
-  16: FloorCarpetClown
-  17: FloorCarpetOffice
-  18: FloorCave
-  19: FloorCaveDrought
-  20: FloorClown
-  21: FloorDark
-  22: FloorDarkDiagonal
-  23: FloorDarkDiagonalMini
-  24: FloorDarkHerringbone
-  25: FloorDarkMini
-  26: FloorDarkMono
-  27: FloorDarkOffset
-  28: FloorDarkPavement
-  29: FloorDarkPavementVertical
-  30: FloorDarkPlastic
-  31: FloorDirt
-  32: FloorEighties
-  33: FloorElevatorShaft
-  34: FloorFreezer
-  35: FloorGlass
-  36: FloorGold
-  37: FloorGrass
-  38: FloorGrassDark
-  39: FloorGrassJungle
-  40: FloorGrassLight
-  41: FloorGreenCircuit
-  42: FloorGym
-  43: FloorHydro
-  44: FloorKitchen
-  45: FloorLaundry
-  46: FloorLino
-  47: FloorMetalDiamond
-  48: FloorMime
-  49: FloorMono
-  50: FloorPlastic
-  51: FloorRGlass
-  52: FloorReinforced
-  53: FloorRockVault
-  54: FloorShowroom
-  55: FloorShuttleBlue
-  56: FloorShuttleOrange
-  57: FloorShuttlePurple
-  58: FloorShuttleRed
-  59: FloorShuttleWhite
-  60: FloorSilver
-  61: FloorSnow
-  62: FloorSteel
-  63: FloorSteelDiagonal
-  64: FloorSteelDiagonalMini
-  65: FloorSteelDirty
-  66: FloorSteelHerringbone
-  67: FloorSteelMini
-  68: FloorSteelMono
-  69: FloorSteelOffset
-  70: FloorSteelPavement
-  71: FloorSteelPavementVertical
-  72: FloorTechMaint
-  73: FloorTechMaint2
-  74: FloorTechMaint3
-  75: FloorWhite
-  76: FloorWhiteDiagonal
-  77: FloorWhiteDiagonalMini
-  78: FloorWhiteHerringbone
-  79: FloorWhiteMini
-  80: FloorWhiteMono
-  81: FloorWhiteOffset
-  82: FloorWhitePavement
-  83: FloorWhitePavementVertical
-  84: FloorWhitePlastic
-  85: FloorWood
-  86: FloorWoodTile
-  87: Lattice
-  88: Plating
+  13: FloorBasaslt
+  14: FloorBlue
+  15: FloorBlueCircuit
+  16: FloorBoxing
+  17: FloorCarpetClown
+  18: FloorCarpetOffice
+  19: FloorCave
+  20: FloorCaveDrought
+  21: FloorClown
+  22: FloorDark
+  23: FloorDarkDiagonal
+  24: FloorDarkDiagonalMini
+  25: FloorDarkHerringbone
+  26: FloorDarkMini
+  27: FloorDarkMono
+  28: FloorDarkOffset
+  29: FloorDarkPavement
+  30: FloorDarkPavementVertical
+  31: FloorDarkPlastic
+  32: FloorDirt
+  33: FloorEighties
+  34: FloorElevatorShaft
+  35: FloorFreezer
+  36: FloorGlass
+  37: FloorGold
+  38: FloorGrass
+  39: FloorGrassDark
+  40: FloorGrassJungle
+  41: FloorGrassLight
+  42: FloorGreenCircuit
+  43: FloorGym
+  44: FloorHydro
+  45: FloorKitchen
+  46: FloorLaundry
+  47: FloorLava
+  48: FloorLino
+  49: FloorMetalDiamond
+  50: FloorMime
+  51: FloorMining
+  52: FloorMono
+  53: FloorPlastic
+  54: FloorRGlass
+  55: FloorReinforced
+  56: FloorRockVault
+  57: FloorShowroom
+  58: FloorShuttleBlue
+  59: FloorShuttleOrange
+  60: FloorShuttlePurple
+  61: FloorShuttleRed
+  62: FloorShuttleWhite
+  63: FloorSilver
+  64: FloorSnow
+  65: FloorSteel
+  66: FloorSteelDiagonal
+  67: FloorSteelDiagonalMini
+  68: FloorSteelDirty
+  69: FloorSteelHerringbone
+  70: FloorSteelMini
+  71: FloorSteelMono
+  72: FloorSteelOffset
+  73: FloorSteelPavement
+  74: FloorSteelPavementVertical
+  75: FloorTechMaint
+  76: FloorTechMaint2
+  77: FloorTechMaint3
+  78: FloorWhite
+  79: FloorWhiteDiagonal
+  80: FloorWhiteDiagonalMini
+  81: FloorWhiteHerringbone
+  82: FloorWhiteMini
+  83: FloorWhiteMono
+  84: FloorWhiteOffset
+  85: FloorWhitePavement
+  86: FloorWhitePavementVertical
+  87: FloorWhitePlastic
+  88: FloorWood
+  89: FloorWoodTile
+  90: Lattice
+  91: Plating
 entities:
 - uid: 0
   components:
   - type: MetaData
-  - pos: 2.2710133,-2.4148211
-    parent: null
+  - pos: 0.48958334,0.74920964
+    parent: invalid
     type: Transform
   - chunks:
-      -1,0:
-        ind: -1,0
-        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAFQAAABUAAABYAAAAWAAAAEgAAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAD4AAAAVAAAAPgAAAD4AAAAVAAAAPgAAAD4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAAA+AAAAFQAAABUAAAAVAAAAFQAAABUAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAPgAAABUAAAA+AAAAPgAAABUAAAA+AAAAPgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAABUAAAAVAAAAWAAAAFgAAABLAAAAWAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD4AAAAVAAAAPgAAAFgAAABLAAAASwAAAEsAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAFQAAAD4AAABYAAAASwAAAEsAAABLAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPgAAABUAAAA+AAAAWAAAAEsAAABLAAAASwAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAAAVAAAAPgAAAFgAAABYAAAASwAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAFQAAABUAAAAVAAAAFQAAABUAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAABYAAAAFQAAABUAAAAVAAAAFQAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcAAABYAAAAPgAAAD4AAAAVAAAAFQAAABUAAAA+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAAWAAAAD4AAAA+AAAAFQAAABUAAAAVAAAAPgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAAPgAAAD4AAAA+AAAAPgAAAD4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       -1,-1:
         ind: -1,-1
-        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAAWAAAAFgAAABIAAAASAAAAEgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAWAAAAFgAAABYAAAASAAAAEgAAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPgAAABUAAAA+AAAAWAAAAEgAAABIAAAANAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAAAVAAAAPgAAAFgAAABIAAAASAAAADQAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+AAAAFQAAAD4AAABYAAAASAAAAEgAAABYAAAAWAAAAA==
+        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWgAAAFoAAABbAAAAWwAAAFsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFoAAABbAAAARAAAADQAAAA0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFoAAABbAAAARAAAAFsAAABbAAAAWwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABaAAAAWwAAADQAAABbAAAATQAAAE0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWgAAAFsAAAAxAAAAMQAAAFsAAABbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFoAAABbAAAANAAAAFsAAAA0AAAATQAAAA==
       0,-1:
         ind: 0,-1
-        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAWAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD4AAAAVAAAAPgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+AAAAFQAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPgAAABUAAAA+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFsAAABbAAAAWgAAAFoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAARAAAAFsAAABaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWwAAAFsAAABEAAAAWwAAAFoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE0AAABbAAAANAAAAFsAAABaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABbAAAAMQAAADEAAABbAAAAWgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANAAAAFsAAAA0AAAAWwAAAFoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+      -1,0:
+        ind: -1,0
+        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFoAAABbAAAARAAAAFsAAABbAAAAWwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWgAAAFsAAABEAAAARAAAAE0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFoAAABaAAAAWwAAADQAAABbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       0,0:
         ind: 0,0
-        tiles: FQAAABUAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAA+AAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAPgAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAAD4AAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAVAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+AAAAFQAAAD4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPgAAABUAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD4AAAAVAAAAPgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+AAAAFQAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAABUAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+AAAAWAAAAFcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPgAAAFgAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        tiles: WwAAAFsAAABEAAAAWwAAAFoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAABEAAAAWwAAAFoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAAWwAAAFoAAABaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
     type: MapGrid
   - type: Broadphase
   - angularDamping: 0.05
@@ -122,549 +125,155 @@ entities:
     type: Physics
   - fixtures: []
     type: Fixtures
+  - type: OccluderTree
+  - type: Shuttle
+  - nextUpdate: 1639.563701
+    type: GridPathfinding
   - gravityShakeSound: !type:SoundPathSpecifier
       path: /Audio/Effects/alert.ogg
-    enabled: True
     type: Gravity
   - chunkCollection:
       -1,0:
         0:
-          color: '#52B4E996'
-          id: FullTileOverlayGreyscale
-          coordinates: -3,5
-        1:
-          color: '#52B4E996'
-          id: FullTileOverlayGreyscale
-          coordinates: -3,6
-        2:
-          color: '#52B4E996'
-          id: FullTileOverlayGreyscale
-          coordinates: -3,7
-        3:
-          color: '#52B4E996'
-          id: FullTileOverlayGreyscale
-          coordinates: -2,6
-        4:
-          color: '#52B4E996'
-          id: FullTileOverlayGreyscale
-          coordinates: -4,6
-        5:
-          color: '#334E6DC8'
-          id: FullTileOverlayGreyscale
-          coordinates: -3,10
-        11:
           color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -1,1
-        12:
-          color: '#FFFFFFFF'
-          id: Bot
+          id: LoadingArea
           coordinates: -2,1
-        13:
+      0,0:
+        1:
+          color: '#FFFFFFFF'
+          id: LoadingArea
+          coordinates: 0,1
+      -1,-1:
+        2:
           color: '#FFFFFFFF'
           id: Bot
-          coordinates: -1,3
-        14:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -2,3
-        15:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -4,3
-        16:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -5,3
-        17:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -5,1
-        18:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -4,1
-        21:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -7,1
-        22:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -7,2
-        23:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -7,3
-        24:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -6,5
-        25:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -6,6
-        26:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -6,7
-        30:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -1,11
-        31:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -1,12
-        32:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -5,12
-        33:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -5,11
-        34:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -3,12
-        35:
-          color: '#FFFFFFFF'
-          id: Arrows
-          coordinates: -3,11
-        36:
-          color: '#334E6DC8'
-          id: HalfTileOverlayGreyscale180
-          coordinates: -4,11
-        37:
-          color: '#334E6DC8'
-          id: HalfTileOverlayGreyscale180
-          coordinates: -2,11
-        38:
-          color: '#334E6DC8'
-          id: QuarterTileOverlayGreyscale90
-          coordinates: -4,9
-        39:
-          color: '#334E6DC8'
-          id: QuarterTileOverlayGreyscale90
-          coordinates: -5,9
-        40:
-          color: '#334E6DC8'
-          id: QuarterTileOverlayGreyscale90
-          coordinates: -6,9
-        41:
-          color: '#334E6DC8'
-          id: QuarterTileOverlayGreyscale
-          coordinates: -2,9
-        42:
-          color: '#334E6DC8'
-          id: QuarterTileOverlayGreyscale
-          coordinates: -1,9
-      0,-1:
+          coordinates: -2,-1
         6:
           color: '#FFFFFFFF'
           id: Bot
-          coordinates: 0,-2
+          coordinates: -4,-3
         7:
           color: '#FFFFFFFF'
           id: Bot
-          coordinates: 0,-1
-      0,0:
+          coordinates: -4,-1
         8:
           color: '#FFFFFFFF'
           id: Bot
-          coordinates: 1,1
+          coordinates: -2,-5
         9:
           color: '#FFFFFFFF'
           id: Bot
-          coordinates: 1,2
+          coordinates: -1,-5
+      0,-1:
+        3:
+          color: '#FFFFFFFF'
+          id: Bot
+          coordinates: 0,-1
+        4:
+          color: '#FFFFFFFF'
+          id: Bot
+          coordinates: 2,-1
+        5:
+          color: '#FFFFFFFF'
+          id: Bot
+          coordinates: 2,-3
         10:
           color: '#FFFFFFFF'
           id: Bot
-          coordinates: 1,3
-        27:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: 0,5
-        28:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: 0,6
-        29:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: 0,7
-        43:
-          color: '#334E6DC8'
-          id: QuarterTileOverlayGreyscale
-          coordinates: 0,9
-      -1,-1:
-        19:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -6,-2
-        20:
-          color: '#FFFFFFFF'
-          id: Bot
-          coordinates: -6,-1
+          coordinates: 0,-5
     type: DecalGrid
   - tiles:
-      -5,-2: 0
-      -5,-1: 1
-      -4,-10: 1
-      -4,-4: 0
-      -4,-3: 0
-      -3,-11: 1
-      -3,-8: 0
-      -3,-7: 0
-      -3,-6: 0
-      -2,-11: 1
-      -2,-9: 0
-      -2,-8: 0
-      -2,-7: 0
-      -2,-6: 0
-      -2,-5: 0
-      -2,-4: 0
-      -2,-3: 0
-      -2,-1: 0
-      -1,-11: 1
-      -1,-9: 0
-      -1,-8: 0
-      -1,-7: 0
-      -1,-6: 0
-      -1,-5: 0
-      -1,-4: 0
-      -1,-3: 0
-      -1,-1: 0
-      -5,5: 0
-      -5,6: 0
-      -5,7: 0
-      -4,1: 0
-      -4,2: 0
-      -4,3: 0
-      -4,7: 2
-      -4,8: 0
-      -4,9: 0
-      -3,12: 1
-      -3,13: 1
-      -3,14: 3
-      -2,0: 0
-      -2,1: 0
-      -2,2: 0
-      -2,3: 0
-      -2,4: 0
-      -2,5: 0
-      -2,7: 0
-      -2,8: 0
-      -2,9: 0
-      -2,10: 0
-      -1,0: 0
-      -1,1: 0
-      -1,2: 0
-      -1,3: 0
-      -1,4: 0
-      -1,5: 0
-      -1,7: 0
-      -1,8: 0
-      -1,9: 0
-      -1,10: 0
-      -1,12: 0
-      -1,13: 0
-      -1,14: 4
-      0,-11: 1
-      0,-9: 0
-      0,-8: 0
-      0,-7: 0
-      0,-6: 0
-      0,-5: 0
-      0,-4: 0
-      0,-3: 2
-      1,-11: 1
-      1,-9: 0
-      1,-8: 0
-      1,-7: 0
-      1,-6: 0
-      1,-5: 0
-      1,-4: 0
-      1,-3: 0
-      1,-1: 0
-      2,-11: 1
-      2,-9: 0
-      2,-8: 0
-      2,-7: 0
-      2,-6: 0
-      2,-5: 0
-      2,-4: 0
-      2,-3: 0
-      2,-1: 0
-      3,-11: 1
-      3,-9: 0
-      3,-8: 0
-      3,-7: 0
-      3,-6: 0
-      3,-5: 0
-      3,-4: 0
-      3,-3: 0
-      3,-1: 0
-      4,-11: 1
-      4,-8: 0
-      4,-7: 0
-      4,-6: 0
-      5,-10: 1
-      5,-4: 1
-      5,-3: 1
-      6,-2: 1
-      6,-1: 1
-      0,7: 0
-      0,8: 2
-      0,9: 0
-      0,10: 0
-      0,12: 0
-      0,13: 5
-      0,14: 6
-      0,15: 0
-      1,0: 0
-      1,1: 0
-      1,2: 0
-      1,3: 0
-      1,4: 0
-      1,5: 0
-      1,7: 0
-      1,8: 0
-      1,9: 0
-      1,10: 0
-      1,12: 7
-      1,13: 8
-      1,14: 0
-      1,15: 0
-      2,0: 0
-      2,1: 0
-      2,2: 0
-      2,3: 0
-      2,4: 0
-      2,5: 0
-      2,7: 0
-      2,8: 0
-      2,9: 0
-      2,10: 0
-      2,12: 0
-      2,13: 0
-      2,14: 0
-      3,0: 0
-      3,1: 0
-      3,2: 0
-      3,3: 0
-      3,4: 0
-      3,5: 0
-      3,7: 0
-      3,8: 0
-      3,9: 0
-      3,10: 0
-      4,12: 1
-      4,13: 1
-      4,14: 1
-      5,1: 0
-      5,2: 0
-      5,3: 0
-      5,7: 1
-      5,8: 1
-      5,9: 1
-      6,1: 0
-      6,2: 0
-      6,3: 0
-      6,5: 1
-      6,6: 1
-      6,7: 1
-      0,17: 1
-      1,17: 1
-      2,17: 1
-      3,16: 1
-      -2,16: 1
-      -1,17: 1
-      -4,-9: 0
-      -4,-8: 0
-      -4,-7: 0
-      -4,-6: 0
-      -4,-5: 0
-      -3,-10: 0
-      -3,-9: 0
-      -3,-5: 0
-      -3,-4: 0
-      -3,-3: 0
+      -4,-1: 0
       -3,-2: 0
       -3,-1: 0
-      -2,-10: 0
       -2,-2: 0
-      -1,-10: 0
+      -2,-1: 0
       -1,-2: 0
-      -5,0: 0
-      -5,1: 0
-      -5,2: 0
-      -5,3: 0
-      -5,4: 0
-      -4,0: 0
-      -4,4: 0
-      -3,0: 0
-      -3,1: 0
-      -3,2: 0
-      -3,3: 0
-      -3,4: 0
-      -3,5: 0
-      -3,6: 0
-      -3,7: 0
-      -3,8: 0
-      -3,9: 0
-      -3,10: 0
-      -3,11: 0
-      -2,6: 0
-      -2,11: 0
-      -2,12: 0
-      -2,13: 0
-      -2,14: 9
-      -2,15: 0
-      -1,6: 0
-      -1,11: 0
-      -1,15: 0
-      0,-10: 0
+      -1,-1: 0
       0,-2: 0
-      0,-1: 0
-      1,-10: 0
       1,-2: 0
-      2,-10: 0
-      2,-2: 0
-      3,-10: 0
-      3,-2: 0
-      4,-10: 0
-      4,-9: 0
-      4,-5: 0
-      4,-4: 0
-      4,-3: 0
-      4,-2: 0
-      4,-1: 0
-      5,-9: 0
-      5,-8: 0
-      5,-7: 0
-      5,-6: 0
-      5,-5: 0
-      0,0: 0
-      0,1: 0
-      0,2: 0
-      0,3: 0
-      0,4: 0
-      0,5: 0
-      0,6: 0
-      0,11: 0
-      1,6: 0
-      1,11: 0
-      2,6: 0
-      2,11: 0
-      2,15: 0
-      3,6: 0
-      3,11: 0
-      3,12: 0
-      3,13: 0
-      3,14: 0
-      3,15: 0
-      4,0: 0
-      4,1: 0
-      4,2: 0
-      4,3: 0
-      4,4: 0
-      4,5: 0
-      4,6: 0
-      4,7: 0
-      4,8: 0
-      4,9: 0
-      4,10: 0
-      4,11: 0
-      5,0: 0
-      5,4: 0
-      6,0: 0
-      6,4: 0
-      0,16: 0
-      1,16: 0
-      2,16: 0
-      -1,16: 0
-      -8,0: 0
-      -8,1: 10
-      -8,2: 11
-      -8,3: 12
-      -8,4: 0
-      -8,5: 0
-      -8,6: 0
-      -8,7: 0
-      -8,8: 0
-      -8,9: 0
-      -8,10: 0
-      -7,0: 0
-      -7,1: 0
-      -7,2: 0
-      -7,3: 0
-      -7,4: 0
-      -7,5: 0
-      -7,6: 0
-      -7,7: 0
-      -7,8: 0
-      -7,9: 0
-      -7,10: 0
-      -7,11: 0
-      -7,12: 0
-      -7,13: 13
-      -6,0: 0
-      -6,1: 0
-      -6,2: 0
-      -6,3: 0
-      -6,4: 0
-      -6,5: 0
-      -6,6: 0
-      -6,7: 0
-      -6,8: 2
-      -6,9: 0
-      -6,10: 0
-      -6,11: 0
-      -6,12: 0
-      -6,13: 14
-      -6,14: 15
-      -5,8: 0
-      -5,9: 0
-      -5,10: 0
-      -5,11: 0
-      -5,12: 0
-      -5,13: 0
-      -5,14: 16
-      -4,5: 0
-      -4,6: 0
-      -4,10: 0
-      -4,11: 0
-      -4,12: 0
-      -4,13: 0
-      -4,14: 17
-      -8,-6: 0
-      -8,-5: 0
-      -8,-4: 0
-      -8,-3: 0
-      -8,-2: 0
-      -8,-1: 0
-      -7,-6: 0
-      -7,-5: 0
-      -7,-4: 0
-      -7,-3: 0
-      -7,-2: 0
-      -7,-1: 0
-      -6,-6: 18
-      -6,-5: 0
       -6,-4: 0
-      -6,-3: 2
+      -6,-3: 0
       -6,-2: 0
       -6,-1: 0
       -5,-6: 0
       -5,-5: 0
       -5,-4: 0
       -5,-3: 0
+      -5,-2: 0
+      -5,-1: 0
+      -4,-6: 0
+      -4,-5: 0
+      -4,-4: 0
+      -4,-3: 0
       -4,-2: 0
-      -4,-1: 2
-      -8,11: 0
-      -8,12: 0
+      -3,-6: 0
+      -3,-5: 0
+      -3,-4: 0
+      -3,-3: 0
+      -2,-6: 0
+      -2,-5: 0
+      -2,-4: 0
+      -2,-3: 0
+      -1,-6: 0
+      -1,-5: 0
+      -1,-4: 0
+      -1,-3: 0
+      0,-6: 0
+      0,-5: 0
+      0,-4: 0
+      0,-3: 0
+      0,-1: 0
+      1,-6: 0
+      1,-5: 0
+      1,-4: 0
+      1,-3: 0
+      1,-1: 0
+      2,-6: 0
+      2,-5: 0
+      2,-4: 0
+      2,-3: 0
+      2,-2: 0
+      2,-1: 0
+      3,-6: 0
+      3,-5: 0
+      3,-4: 0
+      3,-3: 0
+      3,-2: 0
+      3,-1: 0
+      4,-4: 0
+      4,-3: 0
+      4,-2: 0
+      4,-1: 0
+      -6,0: 0
+      -5,0: 0
+      -5,1: 0
+      -5,2: 0
+      -4,0: 0
+      -4,1: 0
+      -4,2: 0
+      -3,0: 0
+      -3,1: 0
+      -3,2: 0
+      -2,0: 0
+      -2,1: 0
+      -2,2: 0
+      -1,0: 0
+      -1,1: 0
+      -1,2: 0
+      0,0: 0
+      0,1: 0
+      0,2: 0
+      1,0: 0
+      1,1: 0
+      1,2: 0
+      2,0: 0
+      2,1: 0
+      2,2: 0
+      3,0: 0
+      3,1: 0
+      3,2: 0
+      4,0: 0
     uniqueMixes:
     - volume: 2500
       temperature: 293.15
@@ -681,3026 +290,1099 @@ entities:
       - 0
       - 0
       - 0
-    - volume: 2500
-      immutable: True
-      moles:
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 293.15
-      moles:
-      - 20.619795
-      - 77.56971
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 122.82263
-      moles:
-      - 9.026207
-      - 33.955734
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 282.50452
-      moles:
-      - 21.024963
-      - 79.0939
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 292.48465
-      moles:
-      - 21.774883
-      - 81.91504
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 290.48862
-      moles:
-      - 21.6249
-      - 81.350815
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 293.10843
-      moles:
-      - 21.821754
-      - 82.09136
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 292.98364
-      moles:
-      - 21.812382
-      - 82.0561
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 250.56815
-      moles:
-      - 18.625212
-      - 70.06627
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 220.53749
-      moles:
-      - 16.36866
-      - 61.57734
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 202.38438
-      moles:
-      - 15.004604
-      - 56.445892
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 197.84608
-      moles:
-      - 14.66359
-      - 55.163033
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 147.925
-      moles:
-      - 10.912439
-      - 41.05156
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 256.84375
-      moles:
-      - 19.09677
-      - 71.840225
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 138.84843
-      moles:
-      - 10.230412
-      - 38.485836
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 181.96211
-      moles:
-      - 13.470042
-      - 50.67302
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 192.74052
-      moles:
-      - 14.27995
-      - 53.719814
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-    - volume: 2500
-      temperature: 220.5375
-      moles:
-      - 16.36866
-      - 61.57734
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
-      - 0
       - 0
       - 0
       - 0
       - 0
     type: GridAtmosphere
-  - type: OccluderTree
-  - type: Shuttle
-  - type: GridPathfinding
+  - type: GasTileOverlay
   - type: RadiationGridResistance
 - uid: 1
-  type: SubstationWallBasic
+  type: AirlockGlassShuttle
   components:
-  - pos: -4.5,-0.5
+  - rot: 3.141592653589793 rad
+    pos: -1.5,2.5
     parent: 0
     type: Transform
-  - canCollide: False
-    type: Physics
+  - fixtures:
+    - shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+      density: 100
+    - shape: !type:PhysShapeCircle
+        radius: 0.2
+        position: 0,-0.5
+      hard: False
+      id: docking
+    type: Fixtures
+  - type: AtmosDevice
 - uid: 2
-  type: Thruster
+  type: AirlockGlassShuttle
   components:
-  - rot: 1.5707963267948966 rad
-    pos: -7.5,-4.5
+  - rot: 3.141592653589793 rad
+    pos: 0.5,2.5
     parent: 0
     type: Transform
+  - fixtures:
+    - shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+      density: 100
+    - shape: !type:PhysShapeCircle
+        radius: 0.2
+        position: 0,-0.5
+      hard: False
+      id: docking
+    type: Fixtures
+  - type: AtmosDevice
 - uid: 3
-  type: WallShuttle
+  type: WallShuttleDiagonal
   components:
-  - pos: -7.5,-3.5
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,-4.5
     parent: 0
     type: Transform
 - uid: 4
-  type: AirlockGlassShuttle
+  type: WallShuttle
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -7.5,7.5
+  - rot: 3.141592653589793 rad
+    pos: -2.5,-5.5
     parent: 0
     type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 5
   type: WallShuttle
-  components:
-  - pos: -7.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 6
-  type: AirlockGlassShuttle
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -7.5,5.5
-    parent: 0
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 7
-  type: WallShuttle
-  components:
-  - pos: -7.5,0.5
-    parent: 0
-    type: Transform
-- uid: 8
-  type: WallShuttle
-  components:
-  - pos: -4.5,0.5
-    parent: 0
-    type: Transform
-- uid: 9
-  type: WallShuttle
-  components:
-  - pos: -0.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 10
-  type: WallShuttle
-  components:
-  - pos: 2.5,4.5
-    parent: 0
-    type: Transform
-- uid: 11
-  type: WallShuttle
-  components:
-  - pos: -7.5,4.5
-    parent: 0
-    type: Transform
-- uid: 12
-  type: AirlockGlassShuttle
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -7.5,-0.5
-    parent: 0
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 13
-  type: WallShuttle
-  components:
-  - pos: -7.5,6.5
-    parent: 0
-    type: Transform
-- uid: 14
-  type: AirlockGlassShuttle
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -7.5,-2.5
-    parent: 0
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 15
-  type: WallShuttle
-  components:
-  - pos: -7.5,8.5
-    parent: 0
-    type: Transform
-- uid: 16
-  type: WallShuttle
-  components:
-  - pos: -7.5,9.5
-    parent: 0
-    type: Transform
-- uid: 17
-  type: WallShuttle
-  components:
-  - pos: -7.5,10.5
-    parent: 0
-    type: Transform
-- uid: 18
-  type: WallShuttle
-  components:
-  - pos: -6.5,10.5
-    parent: 0
-    type: Transform
-- uid: 19
-  type: WallShuttle
-  components:
-  - pos: -6.5,11.5
-    parent: 0
-    type: Transform
-- uid: 20
-  type: WallShuttle
-  components:
-  - pos: 1.5,11.5
-    parent: 0
-    type: Transform
-- uid: 21
-  type: ShuttleWindow
-  components:
-  - pos: 2.5,3.5
-    parent: 0
-    type: Transform
-- uid: 22
-  type: ShuttleWindow
-  components:
-  - pos: 1.5,13.5
-    parent: 0
-    type: Transform
-- uid: 23
-  type: ShuttleWindow
-  components:
-  - pos: 0.5,13.5
-    parent: 0
-    type: Transform
-- uid: 24
-  type: ShuttleWindow
-  components:
-  - pos: 0.5,14.5
-    parent: 0
-    type: Transform
-- uid: 25
-  type: ShuttleWindow
-  components:
-  - pos: -0.5,14.5
-    parent: 0
-    type: Transform
-- uid: 26
-  type: ShuttleWindow
-  components:
-  - pos: -1.5,14.5
-    parent: 0
-    type: Transform
-- uid: 27
-  type: ShuttleWindow
-  components:
-  - pos: -4.5,14.5
-    parent: 0
-    type: Transform
-- uid: 28
-  type: ShuttleWindow
-  components:
-  - pos: -5.5,14.5
-    parent: 0
-    type: Transform
-- uid: 29
-  type: ShuttleWindow
-  components:
-  - pos: -5.5,13.5
-    parent: 0
-    type: Transform
-- uid: 30
-  type: ShuttleWindow
-  components:
-  - pos: -6.5,13.5
-    parent: 0
-    type: Transform
-- uid: 31
-  type: ShuttleWindow
-  components:
-  - pos: -6.5,12.5
-    parent: 0
-    type: Transform
-- uid: 32
-  type: ShuttleWindow
-  components:
-  - pos: -3.5,14.5
-    parent: 0
-    type: Transform
-- uid: 33
-  type: ShuttleWindow
-  components:
-  - pos: -2.5,14.5
-    parent: 0
-    type: Transform
-- uid: 34
-  type: WallShuttle
-  components:
-  - pos: 1.5,10.5
-    parent: 0
-    type: Transform
-- uid: 35
-  type: WallShuttle
-  components:
-  - pos: 0.5,10.5
-    parent: 0
-    type: Transform
-- uid: 36
-  type: WallShuttle
-  components:
-  - pos: -0.5,10.5
-    parent: 0
-    type: Transform
-- uid: 37
-  type: WallShuttle
-  components:
-  - pos: -4.5,4.5
-    parent: 0
-    type: Transform
-- uid: 38
-  type: WallShuttle
-  components:
-  - pos: -4.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 39
-  type: WallShuttle
-  components:
-  - pos: -4.5,10.5
-    parent: 0
-    type: Transform
-- uid: 40
-  type: WallShuttle
-  components:
-  - pos: -5.5,10.5
-    parent: 0
-    type: Transform
-- uid: 41
-  type: WallShuttle
-  components:
-  - pos: 2.5,0.5
-    parent: 0
-    type: Transform
-- uid: 42
-  type: WallShuttle
-  components:
-  - pos: -0.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 43
-  type: CableApcExtension
-  components:
-  - pos: -4.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 44
-  type: CableApcExtension
-  components:
-  - pos: 0.5,1.5
-    parent: 0
-    type: Transform
-- uid: 45
-  type: CableApcExtension
-  components:
-  - pos: -6.5,2.5
-    parent: 0
-    type: Transform
-- uid: 46
-  type: CableApcExtension
-  components:
-  - pos: 1.5,4.5
-    parent: 0
-    type: Transform
-- uid: 47
-  type: WallShuttle
-  components:
-  - pos: 2.5,10.5
-    parent: 0
-    type: Transform
-- uid: 48
-  type: WallShuttle
-  components:
-  - pos: -3.5,0.5
-    parent: 0
-    type: Transform
-- uid: 49
-  type: WallShuttle
-  components:
-  - pos: -0.5,8.5
-    parent: 0
-    type: Transform
-- uid: 50
-  type: ShuttleWindow
-  components:
-  - pos: 1.5,12.5
-    parent: 0
-    type: Transform
-- uid: 51
-  type: WallShuttle
-  components:
-  - pos: -4.5,-5.5
-    parent: 0
-    type: Transform
-- uid: 52
-  type: WallShuttle
-  components:
-  - pos: -0.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 53
-  type: WallShuttle
-  components:
-  - pos: 2.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 54
-  type: ShuttleWindow
-  components:
-  - pos: 2.5,1.5
-    parent: 0
-    type: Transform
-- uid: 55
-  type: WallShuttle
-  components:
-  - pos: -0.5,4.5
-    parent: 0
-    type: Transform
-- uid: 56
-  type: ShuttleWindow
-  components:
-  - pos: 2.5,2.5
-    parent: 0
-    type: Transform
-- uid: 57
-  type: AirlockMedicalGlassLocked
-  components:
-  - pos: -2.5,8.5
-    parent: 0
-    type: Transform
-- uid: 58
-  type: WallShuttle
-  components:
-  - pos: -1.5,8.5
-    parent: 0
-    type: Transform
-- uid: 59
-  type: WallShuttle
-  components:
-  - pos: -0.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 60
-  type: ShuttleWindow
-  components:
-  - pos: -0.5,7.5
-    parent: 0
-    type: Transform
-- uid: 61
-  type: WallShuttle
-  components:
-  - pos: -0.5,0.5
-    parent: 0
-    type: Transform
-- uid: 62
-  type: ShuttleWindow
-  components:
-  - pos: -0.5,6.5
-    parent: 0
-    type: Transform
-- uid: 63
-  type: SMESBasic
-  components:
-  - pos: -3.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 64
-  type: WallShuttle
-  components:
-  - pos: -0.5,-5.5
-    parent: 0
-    type: Transform
-- uid: 65
-  type: WindowReinforcedDirectional
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -4.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 66
-  type: WindowReinforcedDirectional
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -0.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 67
-  type: WallShuttle
-  components:
-  - pos: -1.5,-5.5
-    parent: 0
-    type: Transform
-- uid: 68
-  type: WallShuttle
-  components:
-  - pos: -2.5,-5.5
-    parent: 0
-    type: Transform
-- uid: 69
-  type: WallShuttle
-  components:
-  - pos: -3.5,-5.5
-    parent: 0
-    type: Transform
-- uid: 70
-  type: GasOutletInjector
-  components:
-  - pos: -1.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 71
-  type: Thruster
   components:
   - rot: 3.141592653589793 rad
     pos: 1.5,-5.5
     parent: 0
     type: Transform
-- uid: 72
-  type: Thruster
+- uid: 6
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -3.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 7
+  type: WallShuttleDiagonal
   components:
   - rot: -1.5707963267948966 rad
+    pos: -3.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 8
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 9
+  type: WallShuttleDiagonal
+  components:
+  - pos: -4.5,1.5
+    parent: 0
+    type: Transform
+- uid: 10
+  type: ShuttleWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 11
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -0.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 12
+  type: ShuttleWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 13
+  type: WallShuttleDiagonal
+  components:
+  - pos: 1.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 14
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
     pos: 2.5,-4.5
     parent: 0
     type: Transform
-- uid: 73
-  type: CableApcExtension
+- uid: 15
+  type: WallShuttleDiagonal
   components:
-  - pos: -2.5,-4.5
+  - pos: 2.5,-3.5
     parent: 0
     type: Transform
-- uid: 74
-  type: CableApcExtension
-  components:
-  - pos: -2.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 75
-  type: CableApcExtension
-  components:
-  - pos: -2.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 76
-  type: CableApcExtension
-  components:
-  - pos: -2.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 77
-  type: CableApcExtension
-  components:
-  - pos: -5.5,1.5
-    parent: 0
-    type: Transform
-- uid: 78
-  type: ShuttleWindow
-  components:
-  - pos: -0.5,5.5
-    parent: 0
-    type: Transform
-- uid: 79
+- uid: 16
   type: WallShuttle
-  components:
-  - pos: 2.5,9.5
-    parent: 0
-    type: Transform
-- uid: 80
-  type: WallShuttle
-  components:
-  - pos: 2.5,6.5
-    parent: 0
-    type: Transform
-- uid: 81
-  type: CableApcExtension
-  components:
-  - pos: -6.5,4.5
-    parent: 0
-    type: Transform
-- uid: 82
-  type: CableApcExtension
-  components:
-  - pos: -1.5,9.5
-    parent: 0
-    type: Transform
-- uid: 83
-  type: CableMV
-  components:
-  - pos: -4.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 84
-  type: CableApcExtension
-  components:
-  - pos: 0.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 85
-  type: WallShuttle
-  components:
-  - pos: -1.5,4.5
-    parent: 0
-    type: Transform
-- uid: 86
-  type: CableApcExtension
-  components:
-  - pos: -3.5,0.5
-    parent: 0
-    type: Transform
-- uid: 87
-  type: CableMV
-  components:
-  - pos: -3.5,0.5
-    parent: 0
-    type: Transform
-- uid: 88
-  type: PlasmaReinforcedWindowDirectional
   components:
   - rot: 3.141592653589793 rad
+    pos: 3.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 17
+  type: WallShuttleDiagonal
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,2.5
+    parent: 0
+    type: Transform
+- uid: 18
+  type: WallShuttleDiagonal
+  components:
+  - pos: -3.5,2.5
+    parent: 0
+    type: Transform
+- uid: 19
+  type: WallShuttleDiagonal
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,1.5
+    parent: 0
+    type: Transform
+- uid: 20
+  type: WallShuttleDiagonal
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 21
+  type: ShuttleWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 22
+  type: Gyroscope
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -5.5,-1.5
+    parent: 0
+    type: Transform
+  - type: AtmosDevice
+- uid: 23
+  type: ShuttleWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 24
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 25
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 26
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 27
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 28
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 29
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 30
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 31
+  type: ChairPilotSeat
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -0.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 32
+  type: Grille
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 33
+  type: ShuttleWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 34
+  type: GeneratorUranium
+  components:
+  - pos: -1.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 35
+  type: ShuttleWindow
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 36
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -4.5,0.5
+    parent: 0
+    type: Transform
+- uid: 37
+  type: WallShuttleDiagonal
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,1.5
+    parent: 0
+    type: Transform
+- uid: 38
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -3.5,1.5
+    parent: 0
+    type: Transform
+- uid: 39
+  type: WallShuttleDiagonal
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -3.5,0.5
+    parent: 0
+    type: Transform
+- uid: 40
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -2.5,2.5
+    parent: 0
+    type: Transform
+- uid: 41
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 1.5,2.5
+    parent: 0
+    type: Transform
+- uid: 42
+  type: WallShuttleDiagonal
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 1.5,1.5
+    parent: 0
+    type: Transform
+- uid: 43
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,1.5
+    parent: 0
+    type: Transform
+- uid: 44
+  type: WallShuttleDiagonal
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 2.5,0.5
+    parent: 0
+    type: Transform
+- uid: 45
+  type: WallShuttle
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,0.5
+    parent: 0
+    type: Transform
+- uid: 46
+  type: WallShuttleDiagonal
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 3.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 47
+  type: WallShuttleDiagonal
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 2.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 48
+  type: WallShuttleDiagonal
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: -3.5,-5.5
+    parent: 0
+    type: Transform
+- uid: 49
+  type: WallShuttle
+  components:
+  - rot: -1.5707963267948966 rad
     pos: -1.5,-1.5
     parent: 0
     type: Transform
-- uid: 89
-  type: Thruster
+- uid: 50
+  type: CableMV
+  components:
+  - pos: -0.5,0.5
+    parent: 0
+    type: Transform
+- uid: 51
+  type: ShuttleWindow
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 52
+  type: Grille
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 53
+  type: CableHV
+  components:
+  - pos: -0.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 54
+  type: SubstationWallBasic
+  components:
+  - pos: 0.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 55
+  type: GasPipeBend
+  components:
+  - pos: 1.5,0.5
+    parent: 0
+    type: Transform
+- uid: 56
+  type: GasPipeTJunction
   components:
   - rot: 1.5707963267948966 rad
-    pos: -7.5,11.5
+    pos: 1.5,-1.5
     parent: 0
     type: Transform
-- uid: 90
+- uid: 57
+  type: CableHV
+  components:
+  - pos: 0.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 58
+  type: WallShuttle
+  components:
+  - pos: -0.5,2.5
+    parent: 0
+    type: Transform
+- uid: 59
+  type: APCHighCapacity
+  components:
+  - pos: -0.5,2.5
+    parent: 0
+    type: Transform
+- uid: 60
   type: CableMV
   components:
-  - pos: -1.5,8.5
+  - pos: -0.5,1.5
     parent: 0
     type: Transform
-- uid: 91
+- uid: 61
   type: CableMV
   components:
-  - pos: -3.5,-0.5
+  - pos: -0.5,-0.5
     parent: 0
     type: Transform
-- uid: 92
+- uid: 62
+  type: CableMV
+  components:
+  - pos: -0.5,2.5
+    parent: 0
+    type: Transform
+- uid: 63
   type: CableApcExtension
   components:
-  - pos: 1.5,2.5
+  - pos: 0.5,0.5
     parent: 0
     type: Transform
-- uid: 93
-  type: CableApcExtension
-  components:
-  - pos: -6.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 94
-  type: CableApcExtension
-  components:
-  - pos: -1.5,1.5
-    parent: 0
-    type: Transform
-- uid: 95
+- uid: 64
   type: CableApcExtension
   components:
   - pos: -0.5,1.5
     parent: 0
     type: Transform
-- uid: 96
+- uid: 65
   type: CableApcExtension
   components:
-  - pos: -6.5,-1.5
+  - pos: -0.5,2.5
     parent: 0
     type: Transform
-- uid: 97
-  type: WallShuttle
-  components:
-  - pos: 0.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 98
-  type: WallShuttle
-  components:
-  - pos: -4.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 99
-  type: AirlockGlassShuttle
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 2.5,-0.5
-    parent: 0
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 100
-  type: AirlockGlassShuttle
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 2.5,-2.5
-    parent: 0
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 101
-  type: Grille
-  components:
-  - pos: 2.5,3.5
-    parent: 0
-    type: Transform
-- uid: 102
-  type: ShuttleWindow
-  components:
-  - pos: -4.5,7.5
-    parent: 0
-    type: Transform
-- uid: 103
+- uid: 66
   type: CableApcExtension
   components:
-  - pos: -2.5,3.5
+  - pos: -0.5,0.5
     parent: 0
     type: Transform
-- uid: 104
+- uid: 67
   type: CableApcExtension
   components:
-  - pos: -2.5,5.5
+  - pos: -1.5,0.5
     parent: 0
     type: Transform
-- uid: 105
+- uid: 68
   type: CableApcExtension
   components:
-  - pos: -2.5,6.5
+  - pos: -2.5,0.5
     parent: 0
     type: Transform
-- uid: 106
+- uid: 69
   type: CableApcExtension
   components:
-  - pos: -2.5,7.5
+  - pos: -2.5,-0.5
     parent: 0
     type: Transform
-- uid: 107
-  type: CableApcExtension
-  components:
-  - pos: -2.5,8.5
-    parent: 0
-    type: Transform
-- uid: 108
-  type: CableApcExtension
-  components:
-  - pos: 1.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 109
-  type: CableApcExtension
-  components:
-  - pos: 1.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 110
-  type: CableApcExtension
-  components:
-  - pos: 1.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 111
-  type: CableApcExtension
-  components:
-  - pos: 1.5,0.5
-    parent: 0
-    type: Transform
-- uid: 112
-  type: CableApcExtension
-  components:
-  - pos: 1.5,1.5
-    parent: 0
-    type: Transform
-- uid: 113
-  type: CableApcExtension
-  components:
-  - pos: -4.5,1.5
-    parent: 0
-    type: Transform
-- uid: 114
-  type: CableApcExtension
-  components:
-  - pos: -3.5,1.5
-    parent: 0
-    type: Transform
-- uid: 115
-  type: CableApcExtension
-  components:
-  - pos: -2.5,1.5
-    parent: 0
-    type: Transform
-- uid: 116
-  type: CableApcExtension
-  components:
-  - pos: -6.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 117
-  type: CableApcExtension
-  components:
-  - pos: -5.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 118
-  type: CableHV
-  components:
-  - pos: -4.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 119
-  type: CableHV
-  components:
-  - pos: -3.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 120
-  type: CableHV
-  components:
-  - pos: -3.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 121
-  type: CableHV
-  components:
-  - pos: -3.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 122
-  type: GasPort
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -1.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 123
-  type: WindowReinforcedDirectional
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -0.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 124
-  type: Grille
-  components:
-  - pos: -0.5,7.5
-    parent: 0
-    type: Transform
-- uid: 125
-  type: Grille
-  components:
-  - pos: -0.5,6.5
-    parent: 0
-    type: Transform
-- uid: 126
-  type: Grille
-  components:
-  - pos: -0.5,5.5
-    parent: 0
-    type: Transform
-- uid: 127
-  type: Grille
-  components:
-  - pos: -4.5,7.5
-    parent: 0
-    type: Transform
-- uid: 128
-  type: CableMV
-  components:
-  - pos: -2.5,4.5
-    parent: 0
-    type: Transform
-- uid: 129
-  type: CableMV
-  components:
-  - pos: -2.5,3.5
-    parent: 0
-    type: Transform
-- uid: 130
-  type: CableMV
-  components:
-  - pos: -2.5,2.5
-    parent: 0
-    type: Transform
-- uid: 131
-  type: CableMV
-  components:
-  - pos: -2.5,1.5
-    parent: 0
-    type: Transform
-- uid: 132
-  type: CableMV
-  components:
-  - pos: -3.5,1.5
-    parent: 0
-    type: Transform
-- uid: 133
-  type: CableApcExtension
-  components:
-  - pos: -6.5,0.5
-    parent: 0
-    type: Transform
-- uid: 134
-  type: APCHyperCapacity
-  components:
-  - pos: -1.5,8.5
-    parent: 0
-    type: Transform
-- uid: 135
-  type: Thruster
-  components:
-  - pos: -7.5,12.5
-    parent: 0
-    type: Transform
-- uid: 136
+- uid: 70
   type: CableApcExtension
   components:
   - pos: -2.5,-1.5
     parent: 0
     type: Transform
-- uid: 137
+- uid: 71
   type: CableApcExtension
   components:
-  - pos: 1.5,9.5
+  - pos: -2.5,-2.5
     parent: 0
     type: Transform
-- uid: 138
+- uid: 72
   type: CableApcExtension
   components:
-  - pos: 1.5,6.5
+  - pos: -2.5,-3.5
     parent: 0
     type: Transform
-- uid: 139
+- uid: 73
   type: CableApcExtension
   components:
-  - pos: 1.5,7.5
+  - pos: -1.5,-3.5
     parent: 0
     type: Transform
-- uid: 140
+- uid: 74
   type: CableApcExtension
   components:
-  - pos: -6.5,-2.5
+  - pos: -0.5,-3.5
     parent: 0
     type: Transform
-- uid: 141
-  type: WallShuttle
-  components:
-  - pos: -4.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 142
+- uid: 75
   type: CableApcExtension
   components:
-  - pos: -6.5,3.5
+  - pos: 0.5,-3.5
     parent: 0
     type: Transform
-- uid: 143
-  type: WallShuttle
-  components:
-  - pos: 2.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 144
-  type: WallShuttle
-  components:
-  - pos: 2.5,8.5
-    parent: 0
-    type: Transform
-- uid: 145
-  type: AirlockGlassShuttle
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 2.5,7.5
-    parent: 0
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 146
-  type: ShuttleWindow
-  components:
-  - pos: -4.5,5.5
-    parent: 0
-    type: Transform
-- uid: 147
-  type: ShuttleWindow
-  components:
-  - pos: -7.5,1.5
-    parent: 0
-    type: Transform
-- uid: 148
-  type: WallShuttle
-  components:
-  - pos: -1.5,10.5
-    parent: 0
-    type: Transform
-- uid: 149
-  type: ShuttleWindow
-  components:
-  - pos: -4.5,6.5
-    parent: 0
-    type: Transform
-- uid: 150
+- uid: 76
   type: CableApcExtension
-  components:
-  - pos: 0.5,9.5
-    parent: 0
-    type: Transform
-- uid: 151
-  type: CableApcExtension
-  components:
-  - pos: 1.5,8.5
-    parent: 0
-    type: Transform
-- uid: 152
-  type: AirlockGlassShuttle
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 2.5,5.5
-    parent: 0
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 153
-  type: WallShuttle
   components:
   - pos: 1.5,-3.5
     parent: 0
     type: Transform
-- uid: 154
-  type: WallShuttle
+- uid: 77
+  type: CableApcExtension
   components:
-  - pos: -4.5,-2.5
+  - pos: 1.5,-2.5
     parent: 0
     type: Transform
-- uid: 155
-  type: Grille
+- uid: 78
+  type: CableApcExtension
   components:
-  - pos: 2.5,1.5
+  - pos: 1.5,-1.5
     parent: 0
     type: Transform
-- uid: 156
-  type: Grille
+- uid: 79
+  type: CableApcExtension
   components:
-  - pos: -6.5,12.5
+  - pos: 1.5,-0.5
     parent: 0
     type: Transform
-- uid: 157
-  type: Grille
+- uid: 80
+  type: CableApcExtension
   components:
-  - pos: -6.5,13.5
+  - pos: 1.5,0.5
     parent: 0
     type: Transform
-- uid: 158
-  type: Grille
-  components:
-  - pos: -5.5,13.5
-    parent: 0
-    type: Transform
-- uid: 159
-  type: Grille
-  components:
-  - pos: -5.5,14.5
-    parent: 0
-    type: Transform
-- uid: 160
-  type: Grille
-  components:
-  - pos: -4.5,14.5
-    parent: 0
-    type: Transform
-- uid: 161
-  type: Grille
-  components:
-  - pos: -3.5,14.5
-    parent: 0
-    type: Transform
-- uid: 162
-  type: Grille
-  components:
-  - pos: -2.5,14.5
-    parent: 0
-    type: Transform
-- uid: 163
-  type: Grille
-  components:
-  - pos: -1.5,14.5
-    parent: 0
-    type: Transform
-- uid: 164
-  type: Grille
-  components:
-  - pos: -0.5,14.5
-    parent: 0
-    type: Transform
-- uid: 165
-  type: Grille
-  components:
-  - pos: 0.5,14.5
-    parent: 0
-    type: Transform
-- uid: 166
-  type: Grille
-  components:
-  - pos: 0.5,13.5
-    parent: 0
-    type: Transform
-- uid: 167
-  type: Grille
-  components:
-  - pos: 1.5,13.5
-    parent: 0
-    type: Transform
-- uid: 168
-  type: Grille
-  components:
-  - pos: 1.5,12.5
-    parent: 0
-    type: Transform
-- uid: 169
-  type: Grille
-  components:
-  - pos: 2.5,2.5
-    parent: 0
-    type: Transform
-- uid: 170
-  type: WallShuttle
-  components:
-  - pos: -6.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 171
-  type: Grille
-  components:
-  - pos: -7.5,1.5
-    parent: 0
-    type: Transform
-- uid: 172
-  type: Grille
-  components:
-  - pos: -7.5,2.5
-    parent: 0
-    type: Transform
-- uid: 173
-  type: Grille
-  components:
-  - pos: -7.5,3.5
-    parent: 0
-    type: Transform
-- uid: 174
+- uid: 81
   type: CableMV
   components:
-  - pos: -2.5,6.5
+  - pos: -0.5,-1.5
     parent: 0
     type: Transform
-- uid: 175
-  type: Thruster
+- uid: 82
+  type: CableMV
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 2.5,11.5
+  - pos: 0.5,-1.5
     parent: 0
     type: Transform
-- uid: 176
-  type: APCHyperCapacity
+- uid: 83
+  type: WallShuttle
   components:
-  - pos: -3.5,0.5
+  - pos: 0.5,-1.5
     parent: 0
     type: Transform
-- uid: 177
-  type: CableApcExtension
+- uid: 84
+  type: GravityGeneratorMini
   components:
-  - pos: -3.5,-4.5
+  - pos: -0.5,-2.5
     parent: 0
     type: Transform
-- uid: 178
-  type: CableApcExtension
-  components:
-  - pos: -0.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 179
-  type: CableApcExtension
-  components:
-  - pos: 1.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 180
-  type: CableApcExtension
-  components:
-  - pos: -1.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 181
-  type: Thruster
-  components:
-  - pos: 2.5,12.5
-    parent: 0
-    type: Transform
-- uid: 182
-  type: WindowReinforcedDirectional
+  - type: AtmosDevice
+- uid: 85
+  type: ChairPilotSeat
   components:
   - rot: 1.5707963267948966 rad
-    pos: -4.5,-4.5
+    pos: -3.5,-0.5
     parent: 0
     type: Transform
-- uid: 183
-  type: CableMV
-  components:
-  - pos: -2.5,5.5
-    parent: 0
-    type: Transform
-- uid: 184
-  type: CableApcExtension
-  components:
-  - pos: -0.5,9.5
-    parent: 0
-    type: Transform
-- uid: 185
-  type: CableApcExtension
-  components:
-  - pos: -6.5,1.5
-    parent: 0
-    type: Transform
-- uid: 186
-  type: WallShuttle
-  components:
-  - pos: -1.5,0.5
-    parent: 0
-    type: Transform
-- uid: 187
-  type: CableApcExtension
-  components:
-  - pos: -2.5,4.5
-    parent: 0
-    type: Transform
-- uid: 188
-  type: CableApcExtension
-  components:
-  - pos: -1.5,8.5
-    parent: 0
-    type: Transform
-- uid: 189
-  type: Grille
-  components:
-  - pos: -4.5,6.5
-    parent: 0
-    type: Transform
-- uid: 190
-  type: Grille
-  components:
-  - pos: -4.5,5.5
-    parent: 0
-    type: Transform
-- uid: 191
-  type: CableMV
-  components:
-  - pos: -2.5,8.5
-    parent: 0
-    type: Transform
-- uid: 192
-  type: CableApcExtension
-  components:
-  - pos: -2.5,0.5
-    parent: 0
-    type: Transform
-- uid: 193
-  type: WallShuttle
-  components:
-  - pos: -3.5,4.5
-    parent: 0
-    type: Transform
-- uid: 194
-  type: CableApcExtension
-  components:
-  - pos: 1.5,3.5
-    parent: 0
-    type: Transform
-- uid: 195
-  type: CableMV
-  components:
-  - pos: -2.5,7.5
-    parent: 0
-    type: Transform
-- uid: 196
-  type: WallShuttle
-  components:
-  - pos: -3.5,10.5
-    parent: 0
-    type: Transform
-- uid: 197
-  type: ShuttleWindow
-  components:
-  - pos: -7.5,2.5
-    parent: 0
-    type: Transform
-- uid: 198
-  type: ShuttleWindow
-  components:
-  - pos: -7.5,3.5
-    parent: 0
-    type: Transform
-- uid: 199
-  type: WallShuttle
-  components:
-  - pos: -4.5,8.5
-    parent: 0
-    type: Transform
-- uid: 200
-  type: WallShuttle
-  components:
-  - pos: -3.5,8.5
-    parent: 0
-    type: Transform
-- uid: 201
-  type: CableApcExtension
-  components:
-  - pos: -2.5,9.5
-    parent: 0
-    type: Transform
-- uid: 202
-  type: CableApcExtension
-  components:
-  - pos: -3.5,9.5
-    parent: 0
-    type: Transform
-- uid: 203
-  type: CableApcExtension
-  components:
-  - pos: -4.5,9.5
-    parent: 0
-    type: Transform
-- uid: 204
-  type: CableApcExtension
-  components:
-  - pos: -5.5,9.5
-    parent: 0
-    type: Transform
-- uid: 205
-  type: CableApcExtension
-  components:
-  - pos: -6.5,9.5
-    parent: 0
-    type: Transform
-- uid: 206
-  type: CableApcExtension
-  components:
-  - pos: -6.5,8.5
-    parent: 0
-    type: Transform
-- uid: 207
-  type: CableApcExtension
-  components:
-  - pos: -6.5,7.5
-    parent: 0
-    type: Transform
-- uid: 208
-  type: CableApcExtension
-  components:
-  - pos: -6.5,6.5
-    parent: 0
-    type: Transform
-- uid: 209
-  type: CableApcExtension
-  components:
-  - pos: -2.5,10.5
-    parent: 0
-    type: Transform
-- uid: 210
-  type: CableApcExtension
-  components:
-  - pos: -2.5,11.5
-    parent: 0
-    type: Transform
-- uid: 211
-  type: CableApcExtension
-  components:
-  - pos: -2.5,12.5
-    parent: 0
-    type: Transform
-- uid: 212
-  type: CableApcExtension
-  components:
-  - pos: -2.5,13.5
-    parent: 0
-    type: Transform
-- uid: 213
-  type: CableApcExtension
-  components:
-  - pos: -3.5,11.5
-    parent: 0
-    type: Transform
-- uid: 214
-  type: CableApcExtension
-  components:
-  - pos: -4.5,11.5
-    parent: 0
-    type: Transform
-- uid: 215
-  type: CableApcExtension
-  components:
-  - pos: -5.5,11.5
-    parent: 0
-    type: Transform
-- uid: 216
-  type: CableApcExtension
-  components:
-  - pos: -1.5,11.5
-    parent: 0
-    type: Transform
-- uid: 217
-  type: CableApcExtension
-  components:
-  - pos: -0.5,11.5
-    parent: 0
-    type: Transform
-- uid: 218
-  type: CableApcExtension
-  components:
-  - pos: 0.5,11.5
-    parent: 0
-    type: Transform
-- uid: 219
-  type: CableApcExtension
-  components:
-  - pos: -2.5,14.5
-    parent: 0
-    type: Transform
-- uid: 220
-  type: CableApcExtension
-  components:
-  - pos: -1.5,14.5
-    parent: 0
-    type: Transform
-- uid: 221
-  type: CableApcExtension
-  components:
-  - pos: -0.5,14.5
-    parent: 0
-    type: Transform
-- uid: 222
-  type: CableApcExtension
-  components:
-  - pos: 0.5,14.5
-    parent: 0
-    type: Transform
-- uid: 223
-  type: CableApcExtension
-  components:
-  - pos: 0.5,13.5
-    parent: 0
-    type: Transform
-- uid: 224
-  type: CableApcExtension
-  components:
-  - pos: 1.5,13.5
-    parent: 0
-    type: Transform
-- uid: 225
-  type: CableApcExtension
-  components:
-  - pos: 1.5,12.5
-    parent: 0
-    type: Transform
-- uid: 226
-  type: CableApcExtension
-  components:
-  - pos: -3.5,14.5
-    parent: 0
-    type: Transform
-- uid: 227
-  type: CableApcExtension
-  components:
-  - pos: -4.5,14.5
-    parent: 0
-    type: Transform
-- uid: 228
-  type: CableApcExtension
-  components:
-  - pos: -5.5,14.5
-    parent: 0
-    type: Transform
-- uid: 229
-  type: CableApcExtension
-  components:
-  - pos: -5.5,13.5
-    parent: 0
-    type: Transform
-- uid: 230
-  type: CableApcExtension
-  components:
-  - pos: -6.5,13.5
-    parent: 0
-    type: Transform
-- uid: 231
-  type: CableApcExtension
-  components:
-  - pos: -6.5,12.5
-    parent: 0
-    type: Transform
-- uid: 232
-  type: AirlockEngineeringLocked
-  components:
-  - pos: -2.5,0.5
-    parent: 0
-    type: Transform
-- uid: 233
-  type: CableTerminal
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -3.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 234
-  type: CableHV
-  components:
-  - pos: -3.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 235
-  type: CableHV
-  components:
-  - pos: -2.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 236
-  type: CableHV
-  components:
-  - pos: -3.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 237
-  type: CableHV
-  components:
-  - pos: -1.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 238
-  type: GeneratorWallmountAPU
-  components:
-  - pos: -4.5,-3.5
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 239
-  type: GeneratorUranium
-  components:
-  - pos: -3.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 240
-  type: GeneratorUranium
-  components:
-  - pos: -1.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 241
-  type: CableHV
-  components:
-  - pos: -4.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 242
-  type: GasVentPump
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -5.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 243
-  type: GasVentPump
-  components:
-  - rot: 3.141592653589793 rad
-    pos: 0.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 244
-  type: GasVentPump
-  components:
-  - pos: 0.5,6.5
-    parent: 0
-    type: Transform
-- uid: 245
-  type: GasVentPump
-  components:
-  - pos: -5.5,6.5
-    parent: 0
-    type: Transform
-- uid: 246
-  type: GasVentPump
-  components:
-  - pos: -2.5,12.5
-    parent: 0
-    type: Transform
-- uid: 247
-  type: GasVentPump
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -3.5,6.5
-    parent: 0
-    type: Transform
-- uid: 248
-  type: GasPipeTJunction
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -5.5,2.5
-    parent: 0
-    type: Transform
-- uid: 249
-  type: GasPipeTJunction
+- uid: 86
+  type: FirelockGlass
   components:
   - rot: -1.5707963267948966 rad
-    pos: 0.5,2.5
+    pos: -3.5,-1.5
     parent: 0
     type: Transform
-- uid: 250
-  type: GasPipeFourway
+  - type: AtmosDevice
+- uid: 87
+  type: ChairPilotSeat
   components:
-  - pos: -2.5,2.5
+  - rot: 1.5707963267948966 rad
+    pos: -3.5,-2.5
     parent: 0
     type: Transform
-- uid: 251
-  type: GasPipeTJunction
+- uid: 88
+  type: ChairPilotSeat
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-4.5
+    parent: 0
+    type: Transform
+- uid: 89
+  type: CableApcExtension
+  components:
+  - pos: -3.5,-1.5
+    parent: 0
+    type: Transform
+- uid: 90
+  type: ChairPilotSeat
   components:
   - rot: -1.5707963267948966 rad
-    pos: -2.5,6.5
+    pos: 2.5,-2.5
     parent: 0
     type: Transform
-- uid: 252
-  type: GasPipeStraight
+- uid: 91
+  type: ChairPilotSeat
   components:
   - rot: 3.141592653589793 rad
-    pos: -5.5,3.5
+    pos: 0.5,-4.5
     parent: 0
     type: Transform
-- uid: 253
-  type: GasPipeStraight
+- uid: 92
+  type: FirelockGlass
   components:
-  - rot: 3.141592653589793 rad
-    pos: -5.5,4.5
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,-1.5
     parent: 0
     type: Transform
-- uid: 254
-  type: GasPipeStraight
+  - type: AtmosDevice
+- uid: 93
+  type: ChairPilotSeat
   components:
-  - rot: 3.141592653589793 rad
-    pos: -5.5,5.5
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-0.5
     parent: 0
     type: Transform
-- uid: 255
-  type: GasPipeStraight
-  components:
-  - rot: 3.141592653589793 rad
-    pos: 0.5,3.5
-    parent: 0
-    type: Transform
-- uid: 256
-  type: GasPipeStraight
-  components:
-  - rot: 3.141592653589793 rad
-    pos: 0.5,4.5
-    parent: 0
-    type: Transform
-- uid: 257
-  type: GasPipeStraight
-  components:
-  - rot: 3.141592653589793 rad
-    pos: 0.5,5.5
-    parent: 0
-    type: Transform
-- uid: 258
-  type: GasPipeStraight
+- uid: 94
+  type: ChairPilotSeat
   components:
   - rot: 3.141592653589793 rad
     pos: 0.5,-0.5
     parent: 0
     type: Transform
-- uid: 259
-  type: GasPipeStraight
+- uid: 95
+  type: ChairPilotSeat
   components:
   - rot: 3.141592653589793 rad
-    pos: 0.5,0.5
+    pos: -1.5,-0.5
     parent: 0
     type: Transform
-- uid: 260
-  type: GasPipeStraight
+- uid: 96
+  type: ComputerRadar
   components:
   - rot: 3.141592653589793 rad
-    pos: 0.5,1.5
+    pos: -0.5,-0.5
     parent: 0
     type: Transform
-- uid: 261
-  type: GasPipeStraight
+  - type: AtmosDevice
+- uid: 97
+  type: Thruster
+  components:
+  - pos: -5.5,0.5
+    parent: 0
+    type: Transform
+  - type: AtmosDevice
+- uid: 98
+  type: Thruster
   components:
   - rot: 3.141592653589793 rad
-    pos: -5.5,-0.5
+    pos: -5.5,-3.5
     parent: 0
     type: Transform
-- uid: 262
-  type: GasPipeStraight
+  - type: AtmosDevice
+- uid: 99
+  type: Thruster
   components:
   - rot: 3.141592653589793 rad
-    pos: -5.5,0.5
+    pos: 4.5,-3.5
     parent: 0
     type: Transform
-- uid: 263
-  type: GasPipeStraight
+  - type: AtmosDevice
+- uid: 100
+  type: Thruster
   components:
-  - rot: 3.141592653589793 rad
-    pos: -5.5,1.5
+  - pos: 4.5,0.5
     parent: 0
     type: Transform
-- uid: 264
-  type: GasPipeStraight
+  - type: AtmosDevice
+- uid: 101
+  type: Thruster
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 3.5,2.5
+    parent: 0
+    type: Transform
+  - type: AtmosDevice
+- uid: 102
+  type: Thruster
   components:
   - rot: 1.5707963267948966 rad
     pos: -4.5,2.5
     parent: 0
     type: Transform
-- uid: 265
-  type: GasPipeStraight
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -3.5,2.5
-    parent: 0
-    type: Transform
-- uid: 266
-  type: GasPipeStraight
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -1.5,2.5
-    parent: 0
-    type: Transform
-- uid: 267
-  type: GasPipeStraight
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -0.5,2.5
-    parent: 0
-    type: Transform
-- uid: 268
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,1.5
-    parent: 0
-    type: Transform
-- uid: 269
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,0.5
-    parent: 0
-    type: Transform
-- uid: 270
-  type: GasPassiveVent
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -1.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 271
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,3.5
-    parent: 0
-    type: Transform
-- uid: 272
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,4.5
-    parent: 0
-    type: Transform
-- uid: 273
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,5.5
-    parent: 0
-    type: Transform
-- uid: 274
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,7.5
-    parent: 0
-    type: Transform
-- uid: 275
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,8.5
-    parent: 0
-    type: Transform
-- uid: 276
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,9.5
-    parent: 0
-    type: Transform
-- uid: 277
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,10.5
-    parent: 0
-    type: Transform
-- uid: 278
-  type: GasPipeStraight
-  components:
-  - pos: -2.5,11.5
-    parent: 0
-    type: Transform
-- uid: 279
-  type: FirelockGlass
-  components:
-  - pos: -5.5,0.5
-    parent: 0
-    type: Transform
-- uid: 280
-  type: FirelockGlass
-  components:
-  - pos: -6.5,0.5
-    parent: 0
-    type: Transform
-- uid: 281
-  type: FirelockGlass
-  components:
-  - pos: 1.5,0.5
-    parent: 0
-    type: Transform
-- uid: 282
-  type: FirelockGlass
-  components:
-  - pos: 0.5,0.5
-    parent: 0
-    type: Transform
-- uid: 283
-  type: FirelockGlass
-  components:
-  - pos: 1.5,4.5
-    parent: 0
-    type: Transform
-- uid: 284
-  type: FirelockGlass
-  components:
-  - pos: 0.5,4.5
-    parent: 0
-    type: Transform
-- uid: 285
-  type: FirelockGlass
-  components:
-  - pos: -5.5,4.5
-    parent: 0
-    type: Transform
-- uid: 286
-  type: FirelockGlass
-  components:
-  - pos: -6.5,4.5
-    parent: 0
-    type: Transform
-- uid: 287
-  type: ChairPilotSeat
-  components:
-  - pos: -1.5,3.5
-    parent: 0
-    type: Transform
-- uid: 288
-  type: ChairPilotSeat
-  components:
-  - pos: -0.5,3.5
-    parent: 0
-    type: Transform
-- uid: 289
-  type: ChairPilotSeat
-  components:
-  - pos: -4.5,3.5
-    parent: 0
-    type: Transform
-- uid: 290
-  type: ChairPilotSeat
-  components:
-  - pos: -3.5,3.5
-    parent: 0
-    type: Transform
-- uid: 291
-  type: GasPipeBend
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -2.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 292
+  - type: AtmosDevice
+- uid: 103
   type: Thruster
   components:
-  - rot: 3.141592653589793 rad
-    pos: -6.5,-5.5
+  - rot: 1.5707963267948966 rad
+    pos: -4.5,-5.5
     parent: 0
     type: Transform
-- uid: 293
-  type: WallShuttle
-  components:
-  - pos: -6.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 294
-  type: WallShuttle
-  components:
-  - pos: 1.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 295
-  type: PlasmaReinforcedWindowDirectional
+  - type: AtmosDevice
+- uid: 104
+  type: Thruster
   components:
   - rot: -1.5707963267948966 rad
-    pos: -1.5,-1.5
+    pos: 3.5,-5.5
     parent: 0
     type: Transform
-- uid: 296
-  type: PlasmaReinforcedWindowDirectional
-  components:
-  - pos: -1.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 297
-  type: PlasmaReinforcedWindowDirectional
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -1.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 298
-  type: GasPipeBend
-  components:
-  - pos: -1.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 299
-  type: GravityGeneratorMini
+  - type: AtmosDevice
+- uid: 105
+  type: CableApcExtension
   components:
   - pos: -2.5,-4.5
     parent: 0
     type: Transform
-- uid: 300
-  type: AirCanister
-  components:
-  - pos: -1.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 301
-  type: Table
-  components:
-  - pos: -1.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 302
-  type: Table
-  components:
-  - pos: -3.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 303
-  type: HolofanProjector
-  components:
-  - pos: -1.5318584,-0.42628574
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 304
-  type: InflatableWallStack
-  components:
-  - pos: -1.3756084,-0.34816074
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 305
-  type: Welder
-  components:
-  - pos: -3.4381084,-1.3950357
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 306
-  type: ClothingHeadHatWelding
-  components:
-  - pos: -3.5006084,-1.3794107
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 307
-  type: OxygenCanister
+- uid: 106
+  type: CableApcExtension
   components:
   - pos: -3.5,-3.5
     parent: 0
     type: Transform
-- uid: 308
-  type: Gyroscope
+- uid: 107
+  type: CableApcExtension
   components:
-  - pos: -5.5,-4.5
+  - pos: -3.5,0.5
     parent: 0
     type: Transform
-- uid: 309
-  type: Gyroscope
+- uid: 108
+  type: CableApcExtension
   components:
-  - pos: 0.5,-4.5
+  - pos: -2.5,1.5
     parent: 0
     type: Transform
-- uid: 310
-  type: ShuttleWindow
+- uid: 109
+  type: CableApcExtension
   components:
-  - pos: 0.5,-5.5
+  - pos: 1.5,1.5
     parent: 0
     type: Transform
-- uid: 311
-  type: ShuttleWindow
+- uid: 110
+  type: CableApcExtension
   components:
-  - pos: -5.5,-5.5
+  - pos: 2.5,0.5
     parent: 0
     type: Transform
-- uid: 312
-  type: Grille
+- uid: 111
+  type: CableApcExtension
   components:
-  - pos: -5.5,-5.5
+  - pos: 2.5,-3.5
     parent: 0
     type: Transform
-- uid: 313
-  type: AirlockMedicalGlassLocked
+- uid: 112
+  type: CableApcExtension
   components:
-  - pos: -2.5,4.5
+  - pos: 1.5,-4.5
     parent: 0
     type: Transform
-- uid: 314
-  type: Grille
-  components:
-  - pos: 0.5,-5.5
-    parent: 0
-    type: Transform
-- uid: 315
-  type: WallShuttle
-  components:
-  - pos: -5.5,-3.5
-    parent: 0
-    type: Transform
-- uid: 316
-  type: StasisBed
-  components:
-  - pos: -1.5,7.5
-    parent: 0
-    type: Transform
-- uid: 317
-  type: MedicalBed
-  components:
-  - pos: -1.5,6.5
-    parent: 0
-    type: Transform
-- uid: 318
-  type: MedicalBed
-  components:
-  - pos: -1.5,5.5
-    parent: 0
-    type: Transform
-- uid: 319
-  type: BedsheetMedical
-  components:
-  - pos: -1.5,5.5
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 320
-  type: BedsheetMedical
-  components:
-  - pos: -1.5,6.5
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 321
-  type: ClosetEmergencyFilledRandom
-  components:
-  - pos: 0.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 322
-  type: ClosetEmergencyFilledRandom
-  components:
-  - pos: -5.5,-2.5
-    parent: 0
-    type: Transform
-- uid: 323
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -5.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 324
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -5.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 325
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 0.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 326
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 0.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 327
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 0.5,5.5
-    parent: 0
-    type: Transform
-- uid: 328
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 0.5,6.5
-    parent: 0
-    type: Transform
-- uid: 329
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 0.5,7.5
-    parent: 0
-    type: Transform
-- uid: 330
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -5.5,5.5
-    parent: 0
-    type: Transform
-- uid: 331
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -5.5,6.5
-    parent: 0
-    type: Transform
-- uid: 332
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -5.5,7.5
-    parent: 0
-    type: Transform
-- uid: 333
-  type: ChairPilotSeat
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -4.5,1.5
-    parent: 0
-    type: Transform
-- uid: 334
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -6.5,1.5
-    parent: 0
-    type: Transform
-- uid: 335
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -6.5,2.5
-    parent: 0
-    type: Transform
-- uid: 336
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -6.5,3.5
-    parent: 0
-    type: Transform
-- uid: 337
-  type: ChairPilotSeat
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -0.5,1.5
-    parent: 0
-    type: Transform
-- uid: 338
-  type: ChairPilotSeat
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -1.5,1.5
-    parent: 0
-    type: Transform
-- uid: 339
-  type: ChairPilotSeat
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -3.5,1.5
-    parent: 0
-    type: Transform
-- uid: 340
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: 1.5,1.5
-    parent: 0
-    type: Transform
-- uid: 341
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: 1.5,2.5
-    parent: 0
-    type: Transform
-- uid: 342
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: 1.5,3.5
-    parent: 0
-    type: Transform
-- uid: 343
-  type: Wrench
-  components:
-  - pos: -2.4213462,-2.5333743
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 344
-  type: ToolboxElectricalFilled
-  components:
-  - pos: -3.4993823,-1.5213687
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 345
-  type: ClosetEmergencyFilledRandom
-  components:
-  - pos: -5.5,8.5
-    parent: 0
-    type: Transform
-- uid: 346
-  type: ClosetEmergencyFilledRandom
-  components:
-  - pos: 0.5,8.5
-    parent: 0
-    type: Transform
-- uid: 347
-  type: ClosetFireFilled
-  components:
-  - pos: -3.5,-0.5
-    parent: 0
-    type: Transform
-- uid: 348
-  type: LockerMedicineFilled
-  components:
-  - pos: -3.5,7.5
-    parent: 0
-    type: Transform
-- uid: 349
-  type: TableGlass
-  components:
-  - pos: -3.5,5.5
-    parent: 0
-    type: Transform
-- uid: 350
-  type: ChairOfficeLight
-  components:
-  - pos: -3.5,6.5
-    parent: 0
-    type: Transform
-- uid: 351
-  type: MedkitFilled
-  components:
-  - pos: -3.5306323,5.678626
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 352
-  type: MedkitOxygenFilled
-  components:
-  - pos: -3.4212573,5.444251
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 353
-  type: AirlockCommandGlassLocked
-  components:
-  - pos: -2.5,10.5
-    parent: 0
-    type: Transform
-- uid: 354
-  type: ComputerEmergencyShuttle
-  components:
-  - pos: -2.5,13.5
-    parent: 0
-    type: Transform
-- uid: 355
-  type: WindowReinforcedDirectional
-  components:
-  - pos: -0.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 356
-  type: WindowReinforcedDirectional
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -0.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 357
-  type: WindowReinforcedDirectional
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -4.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 358
-  type: WindowReinforcedDirectional
-  components:
-  - pos: -4.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 359
-  type: Grille
-  components:
-  - pos: -4.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 360
-  type: Grille
-  components:
-  - pos: -0.5,-4.5
-    parent: 0
-    type: Transform
-- uid: 361
-  type: VendingMachineWallMedical
-  components:
-  - flags: SessionSpecific
-    type: MetaData
-  - pos: -3.5,4.5
-    parent: 0
-    type: Transform
-- uid: 362
-  type: ExtinguisherCabinetFilled
-  components:
-  - pos: -4.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 363
-  type: ExtinguisherCabinetFilled
-  components:
-  - pos: -0.5,-1.5
-    parent: 0
-    type: Transform
-- uid: 364
-  type: ExtinguisherCabinetFilled
-  components:
-  - pos: -0.5,8.5
-    parent: 0
-    type: Transform
-- uid: 365
-  type: ExtinguisherCabinetFilled
-  components:
-  - pos: -4.5,8.5
-    parent: 0
-    type: Transform
-- uid: 366
-  type: ChairPilotSeat
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -2.5,12.5
-    parent: 0
-    type: Transform
-- uid: 367
-  type: ComputerRadar
-  components:
-  - pos: -1.5,13.5
-    parent: 0
-    type: Transform
-- uid: 368
-  type: ComputerComms
-  components:
-  - pos: -3.5,13.5
-    parent: 0
-    type: Transform
-- uid: 369
-  type: TableReinforced
-  components:
-  - pos: -4.5,13.5
-    parent: 0
-    type: Transform
-- uid: 370
-  type: TableReinforced
-  components:
-  - pos: -0.5,13.5
-    parent: 0
-    type: Transform
-- uid: 371
-  type: TableReinforced
-  components:
-  - pos: 0.5,12.5
-    parent: 0
-    type: Transform
-- uid: 372
-  type: TableReinforced
-  components:
-  - pos: 0.5,11.5
-    parent: 0
-    type: Transform
-- uid: 373
-  type: TableReinforced
-  components:
-  - pos: -5.5,11.5
-    parent: 0
-    type: Transform
-- uid: 374
-  type: TableReinforced
-  components:
-  - pos: -5.5,12.5
-    parent: 0
-    type: Transform
-- uid: 375
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -4.5,11.5
-    parent: 0
-    type: Transform
-- uid: 376
-  type: ChairPilotSeat
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -4.5,12.5
-    parent: 0
-    type: Transform
-- uid: 377
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -0.5,11.5
-    parent: 0
-    type: Transform
-- uid: 378
-  type: ChairPilotSeat
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -0.5,12.5
-    parent: 0
-    type: Transform
-- uid: 379
-  type: ToolboxEmergencyFilled
-  components:
-  - pos: -6.515904,9.4287615
-    parent: 0
-    type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 380
-  type: PosterLegitNanotrasenLogo
-  components:
-  - pos: -7.5,9.5
-    parent: 0
-    type: Transform
-- uid: 381
-  type: PosterLegitNanotrasenLogo
-  components:
-  - pos: 2.5,9.5
-    parent: 0
-    type: Transform
-- uid: 382
-  type: Poweredlight
-  components:
-  - rot: 3.141592653589793 rad
-    pos: -3.5,11.5
-    parent: 0
-    type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-- uid: 383
-  type: Poweredlight
-  components:
-  - pos: -1.5,-0.5
-    parent: 0
-    type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-- uid: 384
-  type: Poweredlight
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: -6.5,-1.5
-    parent: 0
-    type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-- uid: 385
-  type: Poweredlight
+- uid: 113
+  type: FirelockGlass
   components:
   - rot: -1.5707963267948966 rad
     pos: 1.5,-1.5
     parent: 0
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-- uid: 386
-  type: Poweredlight
+  - type: AtmosDevice
+- uid: 114
+  type: FirelockGlass
   components:
   - rot: -1.5707963267948966 rad
-    pos: 1.5,6.5
+    pos: 2.5,-1.5
+    parent: 0
+    type: Transform
+  - type: AtmosDevice
+- uid: 115
+  type: CableHV
+  components:
+  - pos: -1.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 116
+  type: ComputerEmergencyShuttle
+  components:
+  - pos: -0.5,1.5
+    parent: 0
+    type: Transform
+  - type: AtmosDevice
+- uid: 117
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 118
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,0.5
+    parent: 0
+    type: Transform
+- uid: 119
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -1.5,0.5
+    parent: 0
+    type: Transform
+- uid: 120
+  type: Poweredlight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 0.5,-0.5
     parent: 0
     type: Transform
   - powerLoad: 0
     type: ApcPowerReceiver
-- uid: 387
+  - type: AtmosDevice
+- uid: 121
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,0.5
+    parent: 0
+    type: Transform
+- uid: 122
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 0.5,0.5
+    parent: 0
+    type: Transform
+- uid: 123
   type: Poweredlight
+  components:
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-0.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - type: AtmosDevice
+- uid: 124
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,0.5
+    parent: 0
+    type: Transform
+- uid: 125
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-0.5
+    parent: 0
+    type: Transform
+- uid: 126
+  type: EmergencyLight
   components:
   - rot: 1.5707963267948966 rad
-    pos: -6.5,6.5
+    pos: -3.5,-1.5
     parent: 0
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-- uid: 388
-  type: Poweredlight
+  - type: AtmosDevice
+  - type: ActiveEmergencyLight
+- uid: 127
+  type: Catwalk
   components:
-  - pos: -1.5,7.5
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-2.5
     parent: 0
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-- uid: 389
-  type: Poweredlight
+- uid: 128
+  type: Catwalk
   components:
-  - rot: 3.141592653589793 rad
-    pos: -3.5,1.5
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-3.5
     parent: 0
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-- uid: 390
-  type: Poweredlight
+- uid: 129
+  type: Catwalk
   components:
-  - pos: -1.5,9.5
+  - rot: -1.5707963267948966 rad
+    pos: 0.5,-3.5
     parent: 0
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
-- uid: 391
+- uid: 130
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -0.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 131
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -1.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 132
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 133
+  type: Catwalk
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -2.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 134
   type: EmergencyLight
   components:
-  - pos: -1.5,3.5
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-1.5
     parent: 0
     type: Transform
+  - type: AtmosDevice
   - type: ActiveEmergencyLight
-- uid: 392
-  type: EmergencyLight
+- uid: 135
+  type: AtmosDeviceFanTiny
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -1.5,2.5
+    parent: 0
+    type: Transform
+- uid: 136
+  type: AtmosDeviceFanTiny
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 0.5,2.5
+    parent: 0
+    type: Transform
+- uid: 137
+  type: GeneratorUranium
+  components:
+  - pos: 0.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 138
+  type: CableHV
+  components:
+  - pos: 0.5,-2.5
+    parent: 0
+    type: Transform
+- uid: 139
+  type: GasPipeBend
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 1.5,-3.5
+    parent: 0
+    type: Transform
+- uid: 140
+  type: GasPipeStraight
   components:
   - rot: 3.141592653589793 rad
-    pos: -3.5,9.5
+    pos: 1.5,-2.5
     parent: 0
     type: Transform
-  - type: ActiveEmergencyLight
-- uid: 393
-  type: ToolboxEmergencyFilled
+- uid: 141
+  type: GasPipeStraight
   components:
-  - pos: 1.494039,-2.6272569
+  - rot: 3.141592653589793 rad
+    pos: 1.5,-0.5
     parent: 0
     type: Transform
-  - canCollide: False
-    type: Physics
-- uid: 394
-  type: WeaponCapacitorRecharger
+- uid: 142
+  type: GasPipeStraight
   components:
-  - pos: 0.5,12.5
+  - rot: 1.5707963267948966 rad
+    pos: 2.5,-1.5
     parent: 0
     type: Transform
-  - containers:
-      charger-slot: !type:ContainerSlot {}
-      charger_slot: !type:ContainerSlot {}
-    type: ContainerContainer
-- uid: 395
-  type: AtmosDeviceFanTiny
+- uid: 143
+  type: GasPipeStraight
   components:
-  - pos: -7.5,5.5
+  - rot: 1.5707963267948966 rad
+    pos: 3.5,-1.5
     parent: 0
     type: Transform
-- uid: 396
-  type: AtmosDeviceFanTiny
+- uid: 144
+  type: GasPipeStraight
   components:
-  - pos: -7.5,7.5
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,0.5
     parent: 0
     type: Transform
-- uid: 397
-  type: AtmosDeviceFanTiny
+- uid: 145
+  type: GasPipeStraight
   components:
-  - pos: 2.5,7.5
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-3.5
     parent: 0
     type: Transform
-- uid: 398
-  type: AtmosDeviceFanTiny
+- uid: 146
+  type: GasVentPump
   components:
-  - pos: 2.5,5.5
+  - rot: 1.5707963267948966 rad
+    pos: -0.5,-3.5
     parent: 0
     type: Transform
-- uid: 399
-  type: AtmosDeviceFanTiny
+- uid: 147
+  type: GasVentPump
   components:
-  - pos: 2.5,-0.5
+  - rot: 1.5707963267948966 rad
+    pos: -0.5,0.5
     parent: 0
     type: Transform
-- uid: 400
-  type: AtmosDeviceFanTiny
+- uid: 148
+  type: GasPort
   components:
-  - pos: 2.5,-2.5
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,-1.5
     parent: 0
     type: Transform
-- uid: 401
-  type: AtmosDeviceFanTiny
+- uid: 149
+  type: AirCanister
   components:
-  - pos: -7.5,-2.5
+  - pos: 4.5,-1.5
     parent: 0
     type: Transform
-- uid: 402
-  type: AtmosDeviceFanTiny
+- uid: 150
+  type: Poweredlight
   components:
-  - pos: -7.5,-0.5
+  - pos: 0.5,-2.5
     parent: 0
     type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - type: AtmosDevice
+- uid: 151
+  type: Poweredlight
+  components:
+  - pos: -1.5,-2.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+  - type: AtmosDevice
 ...


### PR DESCRIPTION
Making a smaller evac shuttle to fit the average crewsize and the theme

<!--
Describe your changes. What did you change, why did you change it, and if needed, how?
If you have left detailed commit messages in your commits, you may leave this blank.
-->
🆑 Kromabae
- fix: Evac shuttle is now smaller to fit better for new projects