### PR TITLE
Remove miner limit for Mining Tiny

### DIFF
--- a/Resources/Prototypes/Maps/Mining/miningtiny.yml
+++ b/Resources/Prototypes/Maps/Mining/miningtiny.yml
@@ -14,5 +14,5 @@
         - SalvageSpecialist
       availableJobs:
         Quartermaster: [ 1, 1 ]
-        SalvageSpecialist: [ 4, 4 ]
+        SalvageSpecialist: [ 4, -1 ]
         CorpSec: [ 1, 1 ]


### PR DESCRIPTION
Personal experience has shown even the smallest stations can get away with more people, given the resources and robustness. Currently, an admin needs to manually unlock the miner limit in order for additional people to join. Even though the target playerbase is 2 people roundstart.

Webedit moment.