### PR TITLE
Evac shuttle does not trigger comms system cooldown when auto called

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -169,7 +169,9 @@ namespace Content.Server.RoundEnd
             ExpectedCountdownEnd = _gameTiming.CurTime + countdownTime;
             Timer.Spawn(countdownTime, _shuttle.CallEmergencyShuttle, _countdownTokenSource.Token);
 
-            ActivateCooldown();
+            if (!autoCall){
+                ActivateCooldown();
+            }
             RaiseLocalEvent(RoundEndSystemChangedEvent.Default);
         }
 


### PR DESCRIPTION
<!--
Describe your changes. What did you change, why did you change it, and if needed, how?
If you have left detailed commit messages in your commits, you may leave this blank.
-->
tbh I did not test it!
