### PR TITLE
Add Anomaly Locator to Science lockers.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -10,6 +10,7 @@
       - id: ClothingMaskSterile
       - id: ClothingOuterCoatLab
       - id: AnomalyScanner
+      - id: AnomalyLocator
         prob: 0.5
         orGroup: Scanner
       - id: NodeScanner


### PR DESCRIPTION
Blorp, you can now track those pesky anomalies that get lost in the mines