### PR TITLE
NPC balance changes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/bear.yml
@@ -71,8 +71,8 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Brute: 5
-        Slash: 10
+        Brute: 10
+        Slash: 5
   - type: Tag
     tags:
     - DoorBumpOpener

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -68,8 +68,8 @@
         path: /Audio/Effects/bite.ogg
       damage:
         types:
-          Piercing: 5
-          Slash: 10
+          Piercing: 6
+          Slash: 4
     - type: TypingIndicator
       proto: alien
     - type: NoSlip

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -29,7 +29,7 @@
   - type: Physics
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
-    baseSprintSpeed : 4
+    baseSprintSpeed : 4.3
   - type: Fixtures
     fixtures:
     - shape:
@@ -63,6 +63,7 @@
     - id: FoodMeatXeno
       amount: 1
   - type: Bloodstream
+    bloodReagent: Xenoblood
     bloodMaxVolume: 50
   - type: CombatMode
     disarmAction:
@@ -76,8 +77,8 @@
     angle: 0
     animation: WeaponArcBite
     damage:
-      groups:
-        Brute: 2
+      types:
+        Piercing: 2
   - type: SolutionContainerManager
     solutions:
       melee:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -68,6 +68,9 @@
       200: Dead
   - type: Stamina
     excess: 200
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 3.0
+    baseSprintSpeed : 3.5
   - type: Bloodstream
     bloodReagent: Xenoblood
     bloodlossDamage:
@@ -85,8 +88,9 @@
      collection: AlienClaw
     animation: WeaponArcBite
     damage:
-      groups:
-        Brute: 12
+      types:
+        Piercing: 5
+        Slash: 10
   - type: Appearance
   - type: DamageStateVisuals
     rotate: true


### PR DESCRIPTION
short and sweet, damage changes for most of the space mobs.

Xenos:
Getting a higher default speed to be more threatening (still slower than a human)
Damage changed to more represent their claws, was group brute 12, is now types slash 10 and piercing 5 (This will cause them to cause bleeding more frequently so be careful)

Carp:
Damage reduced a bit (they used to deal more damage than most mobs) and changed majority to pierce and minority to slash (this will cause them to deal less bleeding but still cause it)

space bears
Swapped damage majority and minority making them cause less bleeding.

Ticks:
They are now faster than a human
damage changed from brute to pierce to simulate as if they are piercing your skin to inject it's poison (also noticed while testing, they don't acutally deal poison damage on hit, they do however inject toxins each hit and they are laced with 5u of it so after 5 hits they are out of toxins)

comments: space adders are kinda similar to ticks with the poison except instaed of 5u they got 50u, not sure if we need to balance that