### PR TITLE
Remove crit health threshold

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -85,7 +85,6 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      90: Critical
       100: Dead
   - type: Stamina
   - type: Destructible


### PR DESCRIPTION
No more crit state for simple space mobs. includes carp, adders, spiders and all other space mobs that don't use the parent for health thresholds
