### PR TITLE
Xeno default speed reduction

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -70,7 +70,7 @@
     excess: 200
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.0
-    baseSprintSpeed : 3.5
+    baseSprintSpeed : 3.0
   - type: Bloodstream
     bloodReagent: Xenoblood
     bloodlossDamage:


### PR DESCRIPTION
Reduce xeno speed from 3.5 to 3 to account for spationaut suit slow down, giving you a chance to run away from them
