### PR TITLE
Requested tweaks to plasma shell price and draw depth

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -3,6 +3,8 @@
   parent: BaseItem
   abstract: true
   components:
+  - type: Sprite
+    netsync: false
   - type: Tag
     tags:
     - Cartridge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -3,9 +3,6 @@
   parent: BaseItem
   abstract: true
   components:
-  - type: Sprite
-    drawdepth: FloorObjects
-    netsync: false
   - type: Tag
     tags:
     - Cartridge

--- a/Resources/Prototypes/Recipes/Lathes/plasmashell.yml
+++ b/Resources/Prototypes/Recipes/Lathes/plasmashell.yml
@@ -3,22 +3,20 @@
   result: PlasmaShell
   completetime: 2
   materials:
-    Plasma: 100
-    Steel: 20
+    Plasma: 10
+    Steel: 10
 
 - type: latheRecipe
   id: MagazinePlasmaRifle
   result: MagazinePlasmaRifleEmpty
   completetime: 5
   materials:
-    Plasteel: 200
-    Steel: 500
+    Steel: 400
 
 - type: latheRecipe
   id: MagazinePlasmaRifleFilled
   result: MagazinePlasmaRifle
   completetime: 5
   materials:
-    Plasma: 1400
-    Plasteel: 200
-    Steel: 780
+    Plasma: 140
+    Steel: 540


### PR DESCRIPTION
<!--
Describe your changes. What did you change, why did you change it, and if needed, how?
If you have left detailed commit messages in your commits, you may leave this blank.
-->
I did the thing, lowered the price drastically on  plasma shells, maybe too much but it should not be more worth to print that instead of printing the SMG mag or shotty shells. Can tweak later if we think it's just too cheap.

also made it so all ammo don't appear understuff, they now have the same drawdepth as all other items