### PR TITLE
Respawn

### DIFF
--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -194,6 +194,12 @@ namespace Content.Client.Ghost
             RaiseNetworkEvent(msg);
         }
 
+        public void GhostRespawn()
+        {
+            var msg = new GhostRespawnRequest();
+            RaiseNetworkEvent(msg);
+        }
+
         public void OpenGhostRoles()
         {
             _console.RemoteExecuteCommand(null, "ghostroles");

--- a/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Gameplay;
+using Content.Client.Gameplay;
 using Content.Client.Ghost;
 using Content.Client.UserInterface.Systems.Ghost.Widgets;
 using Content.Shared.Ghost;
@@ -44,7 +44,7 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         }
 
         Gui.Visible = _system?.IsGhost ?? false;
-        Gui.Update(_system?.AvailableGhostRoleCount, _system?.Player?.CanReturnToBody);
+        Gui.Update(_system?.AvailableGhostRoleCount, _system?.Player?.CanReturnToBody, _system?.Player?.CanGhostRespawn, _system?.Player?.GhostRespawnTimer);
     }
 
     private void OnPlayerRemoved(GhostComponent component)
@@ -132,5 +132,10 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
     private void GhostRolesPressed()
     {
         _system?.OpenGhostRoles();
+    }
+
+    private void GhostRespawnPressed()
+    {
+        _system?.GhostRespawn();
     }
 }

--- a/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
@@ -100,6 +100,7 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         Gui.ReturnToBodyPressed += ReturnToBody;
         Gui.GhostRolesPressed += GhostRolesPressed;
         Gui.TargetWindow.WarpClicked += OnWarpClicked;
+        Gui.GhostRespawnPressed += GhostRespawnPressed;
 
         UpdateGui();
     }
@@ -113,6 +114,7 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         Gui.ReturnToBodyPressed -= ReturnToBody;
         Gui.GhostRolesPressed -= GhostRolesPressed;
         Gui.TargetWindow.WarpClicked -= OnWarpClicked;
+        Gui.GhostRespawnPressed -= GhostRespawnPressed;
 
         Gui.Hide();
     }

--- a/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml
+++ b/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml
@@ -1,9 +1,10 @@
-﻿<widgets:GhostGui xmlns="https://spacestation14.io"
+<widgets:GhostGui xmlns="https://spacestation14.io"
                   xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Ghost.Widgets"
                   HorizontalAlignment="Center">
     <BoxContainer Orientation="Horizontal">
         <Button Name="ReturnToBodyButton" Text="{Loc ghost-gui-return-to-body-button}" />
         <Button Name="GhostWarpButton" Text="{Loc ghost-gui-ghost-warp-button}" />
         <Button Name="GhostRolesButton" />
+        <Button Name="GhostRespawnButton" />
     </BoxContainer>
 </widgets:GhostGui>

--- a/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
@@ -53,11 +53,11 @@ public sealed partial class GhostGui : UIWidget
             }
         }
 
-        GhostRespawnButton.Disabled = !canGhostRespawn ?? true;
+        GhostRespawnButton.Disabled = (!canGhostRespawn ?? true) || (ghostRespawnTime is not null && ghostRespawnTime.Value > 0);
 
         if (ghostRespawnTime is not null && ghostRespawnTime.Value > 0)
-            GhostRespawnButton.Text = "Can Respawn in " + ghostRespawnTime.Value + "s";//TODO loc
-        else if (!(!canGhostRespawn ?? true) && ghostRespawnTime is not null && ghostRespawnTime.Value <= 0)
+            GhostRespawnButton.Text = "Can Respawn in " + (int)Math.Round(ghostRespawnTime.Value) + "s";//TODO loc
+        else if ((!canGhostRespawn ?? true) && (ghostRespawnTime is not null && ghostRespawnTime.Value <= 0))
             GhostRespawnButton.Text = "Waiting for Spawn";//TODO loc
         else
             GhostRespawnButton.Text = "Respawn";

--- a/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
@@ -14,6 +14,7 @@ public sealed partial class GhostGui : UIWidget
     public event Action? RequestWarpsPressed;
     public event Action? ReturnToBodyPressed;
     public event Action? GhostRolesPressed;
+    public event Action? GhostRespawnPressed;
 
     public GhostGui()
     {
@@ -26,6 +27,7 @@ public sealed partial class GhostGui : UIWidget
         GhostWarpButton.OnPressed += _ => RequestWarpsPressed?.Invoke();
         ReturnToBodyButton.OnPressed += _ => ReturnToBodyPressed?.Invoke();
         GhostRolesButton.OnPressed += _ => GhostRolesPressed?.Invoke();
+        GhostRespawnButton.OnPressed += _ => GhostRespawnPressed?.Invoke();
     }
 
     public void Hide()
@@ -34,7 +36,7 @@ public sealed partial class GhostGui : UIWidget
         Visible = false;
     }
 
-    public void Update(int? roles, bool? canReturnToBody)
+    public void Update(int? roles, bool? canReturnToBody, bool? canGhostRespawn, float? ghostRespawnTime)
     {
         ReturnToBodyButton.Disabled = !canReturnToBody ?? true;
 
@@ -50,6 +52,15 @@ public sealed partial class GhostGui : UIWidget
                 GhostRolesButton.StyleClasses.Remove(StyleBase.ButtonCaution);
             }
         }
+
+        GhostRespawnButton.Disabled = !canGhostRespawn ?? true;
+
+        if (ghostRespawnTime is not null && ghostRespawnTime.Value > 0)
+            GhostRespawnButton.Text = "Can Respawn in " + ghostRespawnTime.Value + "s";//TODO loc
+        else if (!(!canGhostRespawn ?? true) && ghostRespawnTime is not null && ghostRespawnTime.Value <= 0)
+            GhostRespawnButton.Text = "Waiting for Spawn";//TODO loc
+        else
+            GhostRespawnButton.Text = "Respawn";
 
         TargetWindow.Populate();
     }

--- a/Content.Server/Cloning/AutoCloningSystem.cs
+++ b/Content.Server/Cloning/AutoCloningSystem.cs
@@ -1,0 +1,192 @@
+using Content.Shared.GameTicking;
+using Content.Shared.Damage;
+using Content.Shared.Examine;
+using Content.Shared.Cloning;
+using Content.Shared.Atmos;
+using Content.Shared.CCVar;
+using Content.Server.Cloning.Components;
+using Content.Server.Mind.Components;
+using Content.Server.Power.EntitySystems;
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.EUI;
+using Content.Server.Humanoid;
+using Content.Server.MachineLinking.System;
+using Content.Server.MachineLinking.Events;
+using Content.Shared.Chemistry.Components;
+using Content.Server.Fluids.EntitySystems;
+using Content.Server.Chat.Systems;
+using Content.Server.Construction;
+using Content.Server.Materials;
+using Content.Server.Stack;
+using Content.Server.Jobs;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.Zombies;
+using Content.Shared.Mobs.Systems;
+using Robust.Server.GameObjects;
+using Robust.Server.Containers;
+using Robust.Server.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Configuration;
+using Robust.Shared.Containers;
+using Robust.Shared.Physics.Components;
+using Content.Shared.Humanoid;
+using Content.Shared.Preferences;
+using Content.Server.Preferences.Managers;
+using Robust.Shared.Prototypes;
+using Content.Server.DetailExaminable;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.Cloning
+{
+    public sealed class AutoCloningSystem : EntitySystem
+    {
+        [Dependency] private readonly IPlayerManager _playerManager = null!;
+        [Dependency] private readonly IPrototypeManager _prototype = default!;
+        [Dependency] private readonly HumanoidAppearanceSystem _humanoidSystem = default!;
+        [Dependency] private readonly ContainerSystem _containerSystem = default!;
+        [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+        [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+        [Dependency] private readonly TransformSystem _transformSystem = default!;
+        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly SpillableSystem _spillableSystem = default!;
+        [Dependency] private readonly ChatSystem _chatSystem = default!;
+        [Dependency] private readonly IConfigurationManager _configManager = default!;
+        [Dependency] private readonly IServerPreferencesManager _prefsManager = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<AutoCloningPodComponent, ComponentInit>(OnComponentInit);
+        }
+
+        private void OnComponentInit(EntityUid uid, AutoCloningPodComponent clonePod, ComponentInit args)
+        {
+            clonePod.BodyContainer = _containerSystem.EnsureContainer<ContainerSlot>(clonePod.Owner, "clonepod-bodyContainer");
+        }
+
+        internal void TransferMindToClone(EntityUid entity, Mind.Mind mind)
+        {
+            mind.TransferTo(entity, ghostCheckOverride: true);
+            mind.UnVisit();
+        }
+
+        private void HandleMindAdded(EntityUid uid, BeingClonedComponent clonedComponent, MindAddedMessage message)
+        {
+            if (clonedComponent.Parent == EntityUid.Invalid ||
+                !EntityManager.EntityExists(clonedComponent.Parent) ||
+                !TryComp<AutoCloningPodComponent>(clonedComponent.Parent, out var AutoCloningPodComponent) ||
+                clonedComponent.Owner != AutoCloningPodComponent.BodyContainer.ContainedEntity)
+            {
+                EntityManager.RemoveComponent<BeingClonedComponent>(clonedComponent.Owner);
+                return;
+            }
+            UpdateStatus(CloningPodStatus.Cloning, AutoCloningPodComponent);
+        }
+
+        private HumanoidCharacterProfile GetPlayerProfile(IPlayerSession p)
+        {
+            return (HumanoidCharacterProfile) _prefsManager.GetPreferences(p.UserId).SelectedCharacter;
+        }
+
+        private EntityUid SpawnAutoClonedPlayer(AutoCloningPodComponent clonePod, IPlayerSession player)
+        {
+            var profile = GetPlayerProfile(player);
+
+            var entity = EntityManager.SpawnEntity(
+            _prototypeManager.Index<SpeciesPrototype>(profile?.Species ?? HumanoidAppearanceSystem.DefaultSpecies).Prototype,
+            Transform(clonePod.Owner).MapPosition);
+
+            if (profile != null)
+            {
+                _humanoidSystem.LoadProfile(entity, profile);
+                EntityManager.GetComponent<MetaDataComponent>(entity).EntityName = profile.Name;
+                if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
+                {
+                    EntityManager.AddComponent<DetailExaminableComponent>(entity).Content = profile.FlavorText;
+                }
+            }
+
+            return entity;
+        }
+
+        public bool TryCloning(EntityUid uid, IPlayerSession player, Mind.Mind mind, AutoCloningPodComponent? clonePod)
+        {
+
+            if (!Resolve(uid, ref clonePod))
+                return false;
+
+            if (HasComp<ActiveCloningPodComponent>(uid))
+                return false;
+
+            if (mind.OwnedEntity != null && !_mobStateSystem.IsDead(mind.OwnedEntity.Value))
+                return false; // Body controlled by mind is not dead
+
+            var mob = SpawnAutoClonedPlayer(clonePod, player);
+
+            var cloneMindReturn = EntityManager.AddComponent<BeingClonedComponent>(mob);
+            cloneMindReturn.Mind = mind;
+            cloneMindReturn.Parent = clonePod.Owner;
+            clonePod.BodyContainer.Insert(mob);
+
+            UpdateStatus(CloningPodStatus.NoMind, clonePod);
+            TransferMindToClone(mob,mind);
+            
+            AddComp<ActiveCloningPodComponent>(uid);
+
+            // TODO: Ideally, components like this should be on a mind entity so this isn't neccesary.
+            // Remove this when 'mind entities' are added.
+            // Add on special job components to the mob.
+            if (mind.CurrentJob != null)
+            {
+                foreach (var special in mind.CurrentJob.Prototype.Special)
+                {
+                    if (special is AddComponentSpecial)
+                        special.AfterEquip(mob);
+                }
+            }
+
+            return true;
+        }
+
+        public void UpdateStatus(CloningPodStatus status, AutoCloningPodComponent cloningPod)
+        {
+            cloningPod.Status = status;
+            _appearance.SetData(cloningPod.Owner, CloningPodVisuals.Status, cloningPod.Status);
+        }
+
+        public override void Update(float frameTime)
+        {
+            foreach (var (_, cloning) in EntityManager.EntityQuery<ActiveCloningPodComponent, AutoCloningPodComponent>())
+            {
+                if (cloning.BodyContainer.ContainedEntity == null)
+                    continue;
+
+                cloning.CloningProgress += frameTime;
+                if (cloning.CloningProgress < cloning.CloningTime)
+                    continue;
+
+                Eject(cloning.Owner, cloning);
+            }
+        }
+
+        public void Eject(EntityUid uid, AutoCloningPodComponent? clonePod)
+        {
+            if (!Resolve(uid, ref clonePod))
+                return;
+
+            if (clonePod.BodyContainer.ContainedEntity is not {Valid: true} entity || clonePod.CloningProgress < clonePod.CloningTime)
+                return;
+
+            EntityManager.RemoveComponent<BeingClonedComponent>(entity);
+            clonePod.BodyContainer.Remove(entity);
+            clonePod.CloningProgress = 0f;
+            UpdateStatus(CloningPodStatus.Idle, clonePod);
+            RemCompDeferred<ActiveCloningPodComponent>(uid);
+        }
+    }
+}

--- a/Content.Server/Cloning/AutoCloningSystem.cs
+++ b/Content.Server/Cloning/AutoCloningSystem.cs
@@ -123,8 +123,8 @@ namespace Content.Server.Cloning
             if (HasComp<ActiveCloningPodComponent>(uid))
                 return false;
 
-            if (mind.OwnedEntity != null && !_mobStateSystem.IsDead(mind.OwnedEntity.Value))
-                return false; // Body controlled by mind is not dead
+            //if (mind.OwnedEntity != null && !_mobStateSystem.IsDead(mind.OwnedEntity.Value))
+            //    return false; // Body controlled by mind is not dead
 
             var mob = SpawnAutoClonedPlayer(clonePod, player);
 

--- a/Content.Server/Cloning/AutoCloningSystem.cs
+++ b/Content.Server/Cloning/AutoCloningSystem.cs
@@ -38,155 +38,154 @@ using Robust.Shared.Prototypes;
 using Content.Server.DetailExaminable;
 using Robust.Shared.Configuration;
 
-namespace Content.Server.Cloning
+namespace Content.Server.Cloning;
+
+public sealed class AutoCloningSystem : EntitySystem
 {
-    public sealed class AutoCloningSystem : EntitySystem
+    [Dependency] private readonly IPlayerManager _playerManager = null!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly HumanoidAppearanceSystem _humanoidSystem = default!;
+    [Dependency] private readonly ContainerSystem _containerSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+    [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
+    [Dependency] private readonly TransformSystem _transformSystem = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SpillableSystem _spillableSystem = default!;
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
+    [Dependency] private readonly IConfigurationManager _configManager = default!;
+    [Dependency] private readonly IServerPreferencesManager _prefsManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly IPlayerManager _playerManager = null!;
-        [Dependency] private readonly IPrototypeManager _prototype = default!;
-        [Dependency] private readonly HumanoidAppearanceSystem _humanoidSystem = default!;
-        [Dependency] private readonly ContainerSystem _containerSystem = default!;
-        [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
-        [Dependency] private readonly AtmosphereSystem _atmosphereSystem = default!;
-        [Dependency] private readonly TransformSystem _transformSystem = default!;
-        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-        [Dependency] private readonly SpillableSystem _spillableSystem = default!;
-        [Dependency] private readonly ChatSystem _chatSystem = default!;
-        [Dependency] private readonly IConfigurationManager _configManager = default!;
-        [Dependency] private readonly IServerPreferencesManager _prefsManager = default!;
-        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+        base.Initialize();
 
-        public override void Initialize()
+        SubscribeLocalEvent<AutoCloningPodComponent, ComponentInit>(OnComponentInit);
+    }
+
+    private void OnComponentInit(EntityUid uid, AutoCloningPodComponent clonePod, ComponentInit args)
+    {
+        clonePod.BodyContainer = _containerSystem.EnsureContainer<ContainerSlot>(clonePod.Owner, "clonepod-bodyContainer");
+    }
+
+    internal void TransferMindToClone(EntityUid entity, Mind.Mind mind)
+    {
+        mind.TransferTo(entity, ghostCheckOverride: true);
+        mind.UnVisit();
+    }
+
+    private void HandleMindAdded(EntityUid uid, BeingClonedComponent clonedComponent, MindAddedMessage message)
+    {
+        if (clonedComponent.Parent == EntityUid.Invalid ||
+            !EntityManager.EntityExists(clonedComponent.Parent) ||
+            !TryComp<AutoCloningPodComponent>(clonedComponent.Parent, out var AutoCloningPodComponent) ||
+            clonedComponent.Owner != AutoCloningPodComponent.BodyContainer.ContainedEntity)
         {
-            base.Initialize();
-
-            SubscribeLocalEvent<AutoCloningPodComponent, ComponentInit>(OnComponentInit);
+            EntityManager.RemoveComponent<BeingClonedComponent>(clonedComponent.Owner);
+            return;
         }
+        UpdateStatus(CloningPodStatus.Cloning, AutoCloningPodComponent);
+    }
 
-        private void OnComponentInit(EntityUid uid, AutoCloningPodComponent clonePod, ComponentInit args)
-        {
-            clonePod.BodyContainer = _containerSystem.EnsureContainer<ContainerSlot>(clonePod.Owner, "clonepod-bodyContainer");
-        }
+    private HumanoidCharacterProfile GetPlayerProfile(IPlayerSession p)
+    {
+        return (HumanoidCharacterProfile) _prefsManager.GetPreferences(p.UserId).SelectedCharacter;
+    }
 
-        internal void TransferMindToClone(EntityUid entity, Mind.Mind mind)
-        {
-            mind.TransferTo(entity, ghostCheckOverride: true);
-            mind.UnVisit();
-        }
+    private EntityUid SpawnAutoClonedPlayer(AutoCloningPodComponent clonePod, IPlayerSession player)
+    {
+        var profile = GetPlayerProfile(player);
 
-        private void HandleMindAdded(EntityUid uid, BeingClonedComponent clonedComponent, MindAddedMessage message)
+        var entity = EntityManager.SpawnEntity(
+        _prototypeManager.Index<SpeciesPrototype>(profile?.Species ?? HumanoidAppearanceSystem.DefaultSpecies).Prototype,
+        Transform(clonePod.Owner).MapPosition);
+
+        if (profile != null)
         {
-            if (clonedComponent.Parent == EntityUid.Invalid ||
-                !EntityManager.EntityExists(clonedComponent.Parent) ||
-                !TryComp<AutoCloningPodComponent>(clonedComponent.Parent, out var AutoCloningPodComponent) ||
-                clonedComponent.Owner != AutoCloningPodComponent.BodyContainer.ContainedEntity)
+            _humanoidSystem.LoadProfile(entity, profile);
+            EntityManager.GetComponent<MetaDataComponent>(entity).EntityName = profile.Name;
+            if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
             {
-                EntityManager.RemoveComponent<BeingClonedComponent>(clonedComponent.Owner);
-                return;
-            }
-            UpdateStatus(CloningPodStatus.Cloning, AutoCloningPodComponent);
-        }
-
-        private HumanoidCharacterProfile GetPlayerProfile(IPlayerSession p)
-        {
-            return (HumanoidCharacterProfile) _prefsManager.GetPreferences(p.UserId).SelectedCharacter;
-        }
-
-        private EntityUid SpawnAutoClonedPlayer(AutoCloningPodComponent clonePod, IPlayerSession player)
-        {
-            var profile = GetPlayerProfile(player);
-
-            var entity = EntityManager.SpawnEntity(
-            _prototypeManager.Index<SpeciesPrototype>(profile?.Species ?? HumanoidAppearanceSystem.DefaultSpecies).Prototype,
-            Transform(clonePod.Owner).MapPosition);
-
-            if (profile != null)
-            {
-                _humanoidSystem.LoadProfile(entity, profile);
-                EntityManager.GetComponent<MetaDataComponent>(entity).EntityName = profile.Name;
-                if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
-                {
-                    EntityManager.AddComponent<DetailExaminableComponent>(entity).Content = profile.FlavorText;
-                }
-            }
-
-            return entity;
-        }
-
-        public bool TryCloning(EntityUid uid, IPlayerSession player, Mind.Mind mind, AutoCloningPodComponent? clonePod)
-        {
-
-            if (!Resolve(uid, ref clonePod))
-                return false;
-
-            if (HasComp<ActiveCloningPodComponent>(uid))
-                return false;
-
-            //if (mind.OwnedEntity != null && !_mobStateSystem.IsDead(mind.OwnedEntity.Value))
-            //    return false; // Body controlled by mind is not dead
-
-            var mob = SpawnAutoClonedPlayer(clonePod, player);
-
-            var cloneMindReturn = EntityManager.AddComponent<BeingClonedComponent>(mob);
-            cloneMindReturn.Mind = mind;
-            cloneMindReturn.Parent = clonePod.Owner;
-            clonePod.BodyContainer.Insert(mob);
-
-            UpdateStatus(CloningPodStatus.NoMind, clonePod);
-            TransferMindToClone(mob,mind);
-            
-            AddComp<ActiveCloningPodComponent>(uid);
-
-            // TODO: Ideally, components like this should be on a mind entity so this isn't neccesary.
-            // Remove this when 'mind entities' are added.
-            // Add on special job components to the mob.
-            if (mind.CurrentJob != null)
-            {
-                foreach (var special in mind.CurrentJob.Prototype.Special)
-                {
-                    if (special is AddComponentSpecial)
-                        special.AfterEquip(mob);
-                }
-            }
-
-            return true;
-        }
-
-        public void UpdateStatus(CloningPodStatus status, AutoCloningPodComponent cloningPod)
-        {
-            cloningPod.Status = status;
-            _appearance.SetData(cloningPod.Owner, CloningPodVisuals.Status, cloningPod.Status);
-        }
-
-        public override void Update(float frameTime)
-        {
-            foreach (var (_, cloning) in EntityManager.EntityQuery<ActiveCloningPodComponent, AutoCloningPodComponent>())
-            {
-                if (cloning.BodyContainer.ContainedEntity == null)
-                    continue;
-
-                cloning.CloningProgress += frameTime;
-                if (cloning.CloningProgress < cloning.CloningTime)
-                    continue;
-
-                Eject(cloning.Owner, cloning);
+                EntityManager.AddComponent<DetailExaminableComponent>(entity).Content = profile.FlavorText;
             }
         }
 
-        public void Eject(EntityUid uid, AutoCloningPodComponent? clonePod)
+        return entity;
+    }
+
+    public bool TryCloning(EntityUid uid, IPlayerSession player, Mind.Mind mind, AutoCloningPodComponent? clonePod)
+    {
+
+        if (!Resolve(uid, ref clonePod))
+            return false;
+
+        if (HasComp<ActiveCloningPodComponent>(uid))
+            return false;
+
+        //if (mind.OwnedEntity != null && !_mobStateSystem.IsDead(mind.OwnedEntity.Value))
+        //    return false; // Body controlled by mind is not dead
+
+        var mob = SpawnAutoClonedPlayer(clonePod, player);
+
+        var cloneMindReturn = EntityManager.AddComponent<BeingClonedComponent>(mob);
+        cloneMindReturn.Mind = mind;
+        cloneMindReturn.Parent = clonePod.Owner;
+        clonePod.BodyContainer.Insert(mob);
+
+        UpdateStatus(CloningPodStatus.NoMind, clonePod);
+        TransferMindToClone(mob,mind);
+        
+        AddComp<ActiveCloningPodComponent>(uid);
+
+        // TODO: Ideally, components like this should be on a mind entity so this isn't neccesary.
+        // Remove this when 'mind entities' are added.
+        // Add on special job components to the mob.
+        if (mind.CurrentJob != null)
         {
-            if (!Resolve(uid, ref clonePod))
-                return;
-
-            if (clonePod.BodyContainer.ContainedEntity is not {Valid: true} entity || clonePod.CloningProgress < clonePod.CloningTime)
-                return;
-
-            EntityManager.RemoveComponent<BeingClonedComponent>(entity);
-            clonePod.BodyContainer.Remove(entity);
-            clonePod.CloningProgress = 0f;
-            UpdateStatus(CloningPodStatus.Idle, clonePod);
-            RemCompDeferred<ActiveCloningPodComponent>(uid);
+            foreach (var special in mind.CurrentJob.Prototype.Special)
+            {
+                if (special is AddComponentSpecial)
+                    special.AfterEquip(mob);
+            }
         }
+
+        return true;
+    }
+
+    public void UpdateStatus(CloningPodStatus status, AutoCloningPodComponent cloningPod)
+    {
+        cloningPod.Status = status;
+        _appearance.SetData(cloningPod.Owner, CloningPodVisuals.Status, cloningPod.Status);
+    }
+
+    public override void Update(float frameTime)
+    {
+        foreach (var (_, cloning) in EntityManager.EntityQuery<ActiveCloningPodComponent, AutoCloningPodComponent>())
+        {
+            if (cloning.BodyContainer.ContainedEntity == null)
+                continue;
+
+            cloning.CloningProgress += frameTime;
+            if (cloning.CloningProgress < cloning.CloningTime)
+                continue;
+
+            Eject(cloning.Owner, cloning);
+        }
+    }
+
+    public void Eject(EntityUid uid, AutoCloningPodComponent? clonePod)
+    {
+        if (!Resolve(uid, ref clonePod))
+            return;
+
+        if (clonePod.BodyContainer.ContainedEntity is not {Valid: true} entity || clonePod.CloningProgress < clonePod.CloningTime)
+            return;
+
+        EntityManager.RemoveComponent<BeingClonedComponent>(entity);
+        clonePod.BodyContainer.Remove(entity);
+        clonePod.CloningProgress = 0f;
+        UpdateStatus(CloningPodStatus.Idle, clonePod);
+        RemCompDeferred<ActiveCloningPodComponent>(uid);
     }
 }

--- a/Content.Server/Cloning/Components/AutoCloningPodComponent.cs
+++ b/Content.Server/Cloning/Components/AutoCloningPodComponent.cs
@@ -1,0 +1,37 @@
+using Content.Shared.Cloning;
+using Content.Shared.Construction.Prototypes;
+using Content.Shared.Materials;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Cloning.Components
+{
+    [RegisterComponent]
+    public sealed class AutoCloningPodComponent : Component
+    {
+        [ViewVariables]
+        public ContainerSlot BodyContainer = default!;
+
+        /// <summary>
+        /// How long the cloning has been going on for.
+        /// </summary>
+        [ViewVariables]
+        public float CloningProgress = 0;
+
+        /// <summary>
+        /// The base amount of time it takes to clone a body
+        /// </summary>
+        [DataField("baseCloningTime")]
+        public float BaseCloningTime = 30f;
+
+        /// <summary>
+        /// The current amount of time it takes to clone a body
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float CloningTime = 30f;
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public CloningPodStatus Status;
+    }
+}

--- a/Content.Server/Cloning/Components/AutoCloningPodComponent.cs
+++ b/Content.Server/Cloning/Components/AutoCloningPodComponent.cs
@@ -5,33 +5,32 @@ using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Server.Cloning.Components
+namespace Content.Server.Cloning.Components;
+
+[RegisterComponent]
+public sealed class AutoCloningPodComponent : Component
 {
-    [RegisterComponent]
-    public sealed class AutoCloningPodComponent : Component
-    {
-        [ViewVariables]
-        public ContainerSlot BodyContainer = default!;
+    [ViewVariables]
+    public ContainerSlot BodyContainer = default!;
 
-        /// <summary>
-        /// How long the cloning has been going on for.
-        /// </summary>
-        [ViewVariables]
-        public float CloningProgress = 0;
+    /// <summary>
+    /// How long the cloning has been going on for.
+    /// </summary>
+    [ViewVariables]
+    public float CloningProgress = 0;
 
-        /// <summary>
-        /// The base amount of time it takes to clone a body
-        /// </summary>
-        [DataField("baseCloningTime")]
-        public float BaseCloningTime = 30f;
+    /// <summary>
+    /// The base amount of time it takes to clone a body
+    /// </summary>
+    [DataField("baseCloningTime")]
+    public float BaseCloningTime = 30f;
 
-        /// <summary>
-        /// The current amount of time it takes to clone a body
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float CloningTime = 30f;
+    /// <summary>
+    /// The current amount of time it takes to clone a body
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float CloningTime = 30f;
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        public CloningPodStatus Status;
-    }
+    [ViewVariables(VVAccess.ReadWrite)]
+    public CloningPodStatus Status;
 }

--- a/Content.Server/Ghost/Components/GhostComponent.cs
+++ b/Content.Server/Ghost/Components/GhostComponent.cs
@@ -11,6 +11,9 @@ namespace Content.Server.Ghost.Components
     {
         public TimeSpan TimeOfDeath { get; set; } = TimeSpan.Zero;
 
+        [DataField("respawnTime")]
+        public float RespawnTime = 1200f;
+
         [DataField("booRadius")]
         public float BooRadius = 3;
 

--- a/Content.Server/Ghost/Components/GhostComponent.cs
+++ b/Content.Server/Ghost/Components/GhostComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Ghost.Components
         public TimeSpan TimeOfDeath { get; set; } = TimeSpan.Zero;
 
         [DataField("respawnTime")]
-        public float RespawnTime = 1200f;
+        public float RespawnTime = 10f;
 
         [DataField("booRadius")]
         public float BooRadius = 3;

--- a/Content.Server/Ghost/Components/GhostComponent.cs
+++ b/Content.Server/Ghost/Components/GhostComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Ghost.Components
         public TimeSpan TimeOfDeath { get; set; } = TimeSpan.Zero;
 
         [DataField("respawnTime")]
-        public float RespawnTime = 10f;
+        public float RespawnTime = 600f;
 
         [DataField("booRadius")]
         public float BooRadius = 3;

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -23,6 +23,8 @@ using Robust.Shared.Enums;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
+using Content.Server.Cloning;
+using Content.Server.Cloning.Components;
 
 namespace Content.Server.Ghost
 {
@@ -70,12 +72,18 @@ namespace Content.Server.Ghost
             foreach (var ghost in EntityManager.EntityQuery<GhostComponent, SharedGhostComponent>(true))
             {
                 var elapsedSinceDeath = _gameTiming.CurTime - ghost.Item1.TimeOfDeath;
-                var timeRemaining = (float)Math.Round(ghost.Item1.RespawnTime - (float)elapsedSinceDeath.TotalSeconds);
+                var timeRemaining = ghost.Item1.RespawnTime - (float)elapsedSinceDeath.TotalSeconds;
 
                 if (!EntityManager.TryGetComponent(ghost.Item1.Owner, out ActorComponent? actor))
                     SetCanGhostRespawn(ghost.Item2, false, 0);
 
-                var autoClonerAvailable = true;
+                var autoClonerAvailable = false;
+
+                foreach (var autoCloner in EntityManager.EntityQuery<AutoCloningPodComponent>(true))
+                {
+                    if (!EntityManager.TryGetComponent(autoCloner.Owner, out ActiveCloningPodComponent? active))
+                        autoClonerAvailable = true;
+                }
 
                 if (autoClonerAvailable && timeRemaining <= 0)
                     SetCanGhostRespawn(ghost.Item2, true, 0);

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -241,15 +241,17 @@ namespace Content.Server.Ghost
         {
             if (args.SenderSession.AttachedEntity is not { Valid: true } attached ||
                 !EntityManager.TryGetComponent(attached, out GhostComponent? ghost) ||
-                !EntityManager.TryGetComponent(attached, out MindComponent? mind) ||
-                mind is null || mind.Mind is null ||
                 !EntityManager.TryGetComponent(attached, out ActorComponent? actor))
+                return;
+
+            var mind = actor.PlayerSession.ContentData()!.Mind;
+            if (mind is null)
                 return;
 
             foreach (var autoCloner in EntityManager.EntityQuery<AutoCloningPodComponent>(true))
             {
                 if (!EntityManager.TryGetComponent(autoCloner.Owner, out ActiveCloningPodComponent? active)) {
-                    if (_autocloning.TryCloning(autoCloner.Owner, actor.PlayerSession, mind.Mind, autoCloner))
+                    if (_autocloning.TryCloning(autoCloner.Owner, actor.PlayerSession, mind, autoCloner))
                         break;
                 }
             }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -244,6 +244,9 @@ namespace Content.Server.Ghost
                 !EntityManager.TryGetComponent(attached, out ActorComponent? actor))
                 return;
 
+            if (!ghost.CanGhostRespawn)
+                return;
+
             var mind = actor.PlayerSession.ContentData()!.Mind;
             if (mind is null)
                 return;

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -65,6 +65,28 @@ namespace Content.Server.Ghost
             SubscribeLocalEvent<RoundEndTextAppendEvent>(_ => MakeVisible(true));
         }
 
+        public override void Update(float frameTime)
+        {
+            foreach (var ghost in EntityManager.EntityQuery<GhostComponent, SharedGhostComponent>(true))
+            {
+                var elapsedSinceDeath = _gameTiming.CurTime - ghost.Item1.TimeOfDeath;
+                var timeRemaining = (float)Math.Round(ghost.Item1.RespawnTime - (float)elapsedSinceDeath.TotalSeconds);
+
+                if (!EntityManager.TryGetComponent(ghost.Item1.Owner, out ActorComponent? actor))
+                    SetCanGhostRespawn(ghost.Item2, false, 0);
+
+                var autoClonerAvailable = true;
+
+                if (autoClonerAvailable && timeRemaining <= 0)
+                    SetCanGhostRespawn(ghost.Item2, true, 0);
+                else if (timeRemaining > 0)
+                    SetCanGhostRespawn(ghost.Item2, false, timeRemaining);
+                else
+                    SetCanGhostRespawn(ghost.Item2, false, 0);
+
+            }
+        }
+
         private void OnActionPerform(EntityUid uid, GhostComponent component, BooActionEvent args)
         {
             if (args.Handled)

--- a/Content.Shared/Ghost/SharedGhostComponent.cs
+++ b/Content.Shared/Ghost/SharedGhostComponent.cs
@@ -55,7 +55,6 @@ namespace Content.Shared.Ghost
             get => _ghostRespawnTimer;
             set
             {
-                if (_ghostRespawnTimer == value) return;
                 _ghostRespawnTimer = value;
                 Dirty();
             }

--- a/Content.Shared/Ghost/SharedGhostComponent.cs
+++ b/Content.Shared/Ghost/SharedGhostComponent.cs
@@ -37,12 +37,42 @@ namespace Content.Shared.Ghost
             }
         }
 
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool CanGhostRespawn
+        {
+            get => _canGhostRespawn;
+            set
+            {
+                if (_canGhostRespawn == value) return;
+                _canGhostRespawn = value;
+                Dirty();
+            }
+        }
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float GhostRespawnTimer
+        {
+            get => _ghostRespawnTimer;
+            set
+            {
+                if (_ghostRespawnTimer == value) return;
+                _ghostRespawnTimer = value;
+                Dirty();
+            }
+        }
+
         [DataField("canReturnToBody")]
         private bool _canReturnToBody;
 
+        [DataField("canGhostRespawn")]
+        private bool _canGhostRespawn;
+
+        [DataField("ghostRespawnTimer")]
+        private float _ghostRespawnTimer;
+
         public override ComponentState GetComponentState()
         {
-            return new GhostComponentState(CanReturnToBody, CanGhostInteract);
+            return new GhostComponentState(CanReturnToBody, CanGhostInteract, CanGhostRespawn, GhostRespawnTimer);
         }
 
         public override void HandleComponentState(ComponentState? curState, ComponentState? nextState)
@@ -56,6 +86,8 @@ namespace Content.Shared.Ghost
 
             CanReturnToBody = state.CanReturnToBody;
             CanGhostInteract = state.CanGhostInteract;
+            CanGhostRespawn = state.CanGhostRespawn;
+            GhostRespawnTimer = state.GhostRespawnTimer;
         }
     }
 
@@ -64,13 +96,19 @@ namespace Content.Shared.Ghost
     {
         public bool CanReturnToBody { get; }
         public bool CanGhostInteract { get; }
+        public bool CanGhostRespawn { get;  }
+        public float GhostRespawnTimer { get; }
 
         public GhostComponentState(
             bool canReturnToBody,
-            bool canGhostInteract)
+            bool canGhostInteract,
+            bool canGhostRespawn,
+            float ghostRespawnTimer)
         {
             CanReturnToBody = canReturnToBody;
             CanGhostInteract = canGhostInteract;
+            CanGhostRespawn = canGhostRespawn;
+            GhostRespawnTimer = ghostRespawnTimer;
         }
     }
 }

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -32,6 +32,12 @@ namespace Content.Shared.Ghost
         {
             component.CanReturnToBody = value;
         }
+
+        public void SetCanGhostRespawn(SharedGhostComponent component, bool value, float timer)
+        {
+            component.CanGhostRespawn = value;
+            component.GhostRespawnTimer = timer;
+        }
     }
 
     /// <summary>
@@ -109,6 +115,14 @@ namespace Content.Shared.Ghost
     /// </summary>
     [Serializable, NetSerializable]
     public sealed class GhostReturnToBodyRequest : EntityEventArgs
+    {
+    }
+
+    /// <summary>
+    /// A client to server request for their ghost to respawn
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed class GhostRespawnRequest : EntityEventArgs
     {
     }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -81,7 +81,7 @@
 
 - type: entity
   id: AutoCloningPod
-  parent: BaseMachinePowered
+  parent: BaseStructure
   name: auto cloning pod
   description: An Advanced Automatic Cloning Pod.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: CloningPod
   parent: BaseMachinePowered
   name: cloning pod
@@ -76,4 +76,45 @@
     containers:
       machine_board: !type:Container
       machine_parts: !type:Container
+      clonepod-bodyContainer: !type:ContainerSlot
+
+
+- type: entity
+  id: AutoCloningPod
+  parent: BaseMachinePowered
+  name: auto cloning pod
+  description: An Advanced Automatic Cloning Pod.
+  components:
+  - type: AutoCloningPod
+  - type: Sprite
+    netsync: false
+    sprite: Structures/Machines/cloning.rsi
+    snapCardinals: true
+    layers:
+      - state: pod_0
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+    - shape:
+        !type:PhysShapeAabb
+        bounds: "-0.25,-0.45,0.25,0.45"
+      density: 190
+      mask:
+      - MachineMask
+      layer:
+      - MachineLayer
+  - type: Appearance
+    visuals:
+      - type: GenericEnumVisualizer
+        key: enum.CloningPodVisuals.Status
+        layer: 0
+        states:
+          enum.CloningPodStatus.Cloning: pod_1
+          enum.CloningPodStatus.NoMind: pod_e
+          enum.CloningPodStatus.Gore: pod_g
+          enum.CloningPodStatus.Idle: pod_0
+  - type: Climbable
+  - type: ContainerContainer
+    containers:
       clonepod-bodyContainer: !type:ContainerSlot

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -81,7 +81,7 @@
 
 - type: entity
   id: AutoCloningPod
-  parent: BaseStructure
+  parent: BaseMachinePowered
   name: auto cloning pod
   description: An Advanced Automatic Cloning Pod.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -81,10 +81,13 @@
 
 - type: entity
   id: AutoCloningPod
-  parent: BaseMachinePowered
+  parent: BaseStructure
   name: auto cloning pod
   description: An Advanced Automatic Cloning Pod.
   components:
+  - type: InteractionOutline
+  - type: Transform
+    noRot: true
   - type: AutoCloningPod
   - type: Sprite
     netsync: false


### PR DESCRIPTION
<!--
Describe your changes. What did you change, why did you change it, and if needed, how?
If you have left detailed commit messages in your commits, you may leave this blank.
-->

Brings respawn functionality via an auto cloning pod.

When a player dies or /ghosts a timer will start from the moment of death/ghosting. When the timer expires, they may respawn in an auto cloner if one is available.

The auto cloner is designed to be an indestructible, immovable piece that works under all conditions. Multiple auto-cloners can be mapped, but the first spawned cloner will be the one used if not already occupied (mutliple cloners can be used at once).

If there are no auto-cloners map or all auto-cloners are in use, the button will be deactivated and a message reading "waiting for spawn" will appear. Once an auto-cloner is available, the player can click the button to spawn as the character they selected in the lobby. 

Players can also play ghost roles and still utilise the auto-cloner, spawning as their originally selected character.

The auto cloner does not need biomass and never fails - otherwise it will operate as the normal cloner does. They player will have no equipment on them once cloned, so if mapped the auto cloner should be placed in proximity to non-access controlled doors and clothing vendors.
